### PR TITLE
fix: configure Vercel output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,5 @@
 {
-  "buildCommand": "npm run build"
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
+  "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- configure Vercel to use Next.js output

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689760acc9a88321a25913bd8940c0b4