### PR TITLE
Ensure embedded videos play with audio and resize correctly

### DIFF
--- a/src/components/EmbedPlayer.tsx
+++ b/src/components/EmbedPlayer.tsx
@@ -17,8 +17,8 @@ export function EmbedPlayer({ src, placeholderTitle }: { src: string; placeholde
         url.searchParams.set('autoplay', '1');
       }
       if (!url.searchParams.has('muted')) {
-        console.log('[EmbedPlayer] Adding missing param: muted=1');
-        url.searchParams.set('muted', '1');
+        console.log('[EmbedPlayer] Adding missing param: muted=0');
+        url.searchParams.set('muted', '0');
       }
       if (!url.searchParams.has('playsinline')) {
         console.log('[EmbedPlayer] Adding missing param: playsinline=1');
@@ -52,7 +52,7 @@ export function EmbedPlayer({ src, placeholderTitle }: { src: string; placeholde
     <div className="w-full h-full" style={{ position: 'relative' }}>
       <iframe
         src={iframeSrc}
-        style={{ width: '100%', border: 'none', aspectRatio: '67 / 119' }}
+        style={{ width: '100%', height: '100%', border: 'none' }}
         allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture"
         allowFullScreen
         title={placeholderTitle || 'Video'}


### PR DESCRIPTION
## Summary
- Unmute Mux embedded videos so sound plays by default
- Remove fixed aspect ratio and allow iframe to expand to container for vertical and horizontal videos

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68976e6c5e948321b1a038c5ae4896a0