### PR TITLE
feat: simplify video screen controls

### DIFF
--- a/src/RehabMiniApp.tsx
+++ b/src/RehabMiniApp.tsx
@@ -3,7 +3,7 @@ import { useEnvReady } from './hooks/useEnvReady';
 import { safeLocalStorage } from './utils/localStorage';
 import { placeholderThumb, placeholderProduct } from './utils/placeholders';
 import { ContinueWatching } from './components/ContinueWatching';
-import { SequenceOverlay } from './components/SequenceOverlay';
+import { VideoScreen } from './components/VideoScreen';
 import { TabButton } from './components/TabButton';
 import { ActivePill } from './components/ActivePill';
 import { Modal } from './components/Modal';
@@ -185,17 +185,9 @@ export default function RehabMiniApp() {
         </div>
       </nav>
 
-      <Modal open={!!viewer} onClose={() => setViewer(null)}>
-        {viewer && (
-          <div className="p-4">
-            <div className="flex items-center justify-between mb-2">
-              <h3 className="text-base font-semibold">{viewer.title}</h3>
-              <button className="text-sm text-gray-400" onClick={() => setViewer(null)}>Close</button>
-            </div>
-            <SequenceOverlay course={sampleCourse} envReady={envReady} />
-          </div>
-        )}
-      </Modal>
+      {viewer && (
+        <VideoScreen course={sampleCourse} title={viewer.title} onClose={() => setViewer(null)} />
+      )}
 
       <Modal open={paywallOpen} onClose={() => setPaywallOpen(false)}>
         <div className="p-4">

--- a/src/components/EmbedPlayer.tsx
+++ b/src/components/EmbedPlayer.tsx
@@ -1,4 +1,4 @@
-export function EmbedPlayer({ src, placeholderTitle }: { src: string; placeholderTitle?: string }) {
+export function EmbedPlayer({ src, placeholderTitle, autoplay = true, muted = false, showControls = false }: { src: string; placeholderTitle?: string; autoplay?: boolean; muted?: boolean; showControls?: boolean }) {
   console.log('[EmbedPlayer] Incoming src:', src);
 
   const isMux = (u: string) => {
@@ -12,22 +12,10 @@ export function EmbedPlayer({ src, placeholderTitle }: { src: string; placeholde
   const ensureParams = (u: string) => {
     try {
       const url = new URL(u);
-      if (!url.searchParams.has('autoplay')) {
-        console.log('[EmbedPlayer] Adding missing param: autoplay=1');
-        url.searchParams.set('autoplay', '1');
-      }
-      if (!url.searchParams.has('muted')) {
-        console.log('[EmbedPlayer] Adding missing param: muted=0');
-        url.searchParams.set('muted', '0');
-      }
-      if (!url.searchParams.has('playsinline')) {
-        console.log('[EmbedPlayer] Adding missing param: playsinline=1');
-        url.searchParams.set('playsinline', '1');
-      }
-      if (!url.searchParams.has('controls')) {
-        console.log('[EmbedPlayer] Adding missing param: controls=1');
-        url.searchParams.set('controls', '1');
-      }
+      url.searchParams.set('autoplay', autoplay ? '1' : '0');
+      url.searchParams.set('muted', muted ? '1' : '0');
+      url.searchParams.set('playsinline', '1');
+      url.searchParams.set('controls', showControls ? '1' : '0');
       return url.toString();
     } catch (err) {
       console.error('[EmbedPlayer] Invalid video URL:', u, err);

--- a/src/components/VideoScreen.tsx
+++ b/src/components/VideoScreen.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { useSequenceRunner } from '../hooks/useSequenceRunner';
+import type { Course } from '../types';
+import { EmbedPlayer } from './EmbedPlayer';
+
+export function VideoScreen({ course, onClose, title }: { course: Course; onClose: () => void; title?: string }) {
+  const s = useSequenceRunner(course);
+
+  useEffect(() => { if (s.mode === 'rest') s.next(); }, [s.mode]);
+
+  const [playTick, setPlayTick] = useState(0);
+  const [muted, setMuted] = useState(true);
+
+  const totalExercises = course.laps.reduce((sum, l) => sum + l.exercises.length, 0);
+  const beforeCurrent = course.laps.slice(0, s.lapIdx).reduce((sum, l) => sum + l.exercises.length, 0);
+  const idxLabel = s.ex ? `${beforeCurrent + s.exIdx + 1}/${totalExercises}` : '';
+
+  const handlePlayPause = () => {
+    if (s.mode === 'playing') s.pause(); else s.play();
+    setPlayTick(t => t + 1);
+  };
+  const handlePrev = () => { s.prev(); setPlayTick(t => t + 1); };
+  const handleNext = () => { s.next(); setPlayTick(t => t + 1); };
+  const handleMute = () => { setMuted(m => !m); setPlayTick(t => t + 1); };
+
+  return (
+    <div className="fixed inset-0 bg-black z-50">
+      <EmbedPlayer
+        key={`${s.ex?.id}-${playTick}-${muted}-${s.mode}`}
+        src={s.ex?.video || ''}
+        placeholderTitle={s.ex?.title || 'Video'}
+        autoplay={s.mode === 'playing'}
+        muted={muted}
+        showControls={false}
+      />
+      <div className="absolute top-4 left-4">
+        <button className="px-4 py-2 bg-black/60 text-white rounded-lg" onClick={onClose}>Exit</button>
+      </div>
+      <div className="absolute top-4 right-4 text-right text-white">
+        {title && <div className="text-sm mb-1">{title}</div>}
+        <div className="text-sm">{s.ex?.title}</div>
+        <div className="text-xs opacity-70">{idxLabel}</div>
+      </div>
+      <div className="absolute bottom-4 left-0 right-0 flex justify-center gap-3 text-white">
+        <button className="px-4 py-2 bg-white/10 rounded-lg" onClick={handlePrev}>◀︎</button>
+        <button className="px-4 py-2 bg-blue-600 rounded-lg" onClick={handlePlayPause}>{s.mode === 'playing' ? 'Pause' : 'Play'}</button>
+        <button className="px-4 py-2 bg-white/10 rounded-lg" onClick={handleNext}>▶︎</button>
+        <button className="px-4 py-2 bg-white/10 rounded-lg" onClick={handleMute}>{muted ? 'Unmute' : 'Mute'}</button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- streamline VideoScreen with basic playback, navigation, and mute controls
- hide native player UI by expanding EmbedPlayer props
- remove envReady usage from RehabMiniApp

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b7c7d0c0832181325865a8907e9c