### PR TITLE
fix: prevent unstyled flash by loading tailwind stylesheet

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,17 +1,28 @@
 import React from 'react';
-import Script from 'next/script';
+import Head from 'next/head';
 import App from '../src/App';
 
 export default function Home() {
   return (
     <>
-      <Script src="https://cdn.tailwindcss.com" strategy="beforeInteractive" />
+      <Head>
+        <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css"
+        />
+      </Head>
       <App />
       <style jsx global>{`
         .no-scrollbar::-webkit-scrollbar { display: none; }
         .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
         @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
         .animate-fadeIn { animation: fadeIn .2s ease-out; }
+        .line-clamp-2 {
+          overflow: hidden;
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 2;
+        }
       `}</style>
     </>
   );


### PR DESCRIPTION
## Summary
- load Tailwind CSS via stylesheet instead of runtime script to avoid FOUC
- add custom line-clamp styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898537fc3008321b198e7b1e68483bc