### PR TITLE
fix: load tailwind script globally before render

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import type { AppProps } from 'next/app';
+import Script from 'next/script';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <Script src="https://cdn.tailwindcss.com" strategy="beforeInteractive" />
+      <Component {...pageProps} />
+      <style jsx global>{`
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+        .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+        @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
+        .animate-fadeIn { animation: fadeIn .2s ease-out; }
+        .line-clamp-2 {
+          overflow: hidden;
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 2;
+        }
+      `}</style>
+    </>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,18 +1,6 @@
 import React from 'react';
-import Script from 'next/script';
 import App from '../src/App';
 
 export default function Home() {
-  return (
-    <>
-      <Script src="https://cdn.tailwindcss.com" strategy="beforeInteractive" />
-      <App />
-      <style jsx global>{`
-        .no-scrollbar::-webkit-scrollbar { display: none; }
-        .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
-        @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
-        .animate-fadeIn { animation: fadeIn .2s ease-out; }
-      `}</style>
-    </>
-  );
+  return <App />;
 }


### PR DESCRIPTION
## Summary
- use Next.js Script with `beforeInteractive` to load Tailwind before page render
- move global utility styles and Tailwind loader to `_app.tsx`, simplifying index page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898537fc3008321b198e7b1e68483bc