### PR TITLE
Add course categories and round-based training structure

### DIFF
--- a/src/RehabMiniApp.tsx
+++ b/src/RehabMiniApp.tsx
@@ -2,21 +2,23 @@ import { useEffect, useMemo, useState } from 'react';
 import { retrieveLaunchParams } from '@telegram-apps/sdk';
 import { useEnvReady } from './hooks/useEnvReady';
 import { safeLocalStorage } from './utils/localStorage';
-import { placeholderThumb, placeholderProduct } from './utils/placeholders';
-import { ContinueWatching } from './components/ContinueWatching';
+import { placeholderProduct } from './utils/placeholders';
 import { VideoScreen } from './components/VideoScreen';
 import { TabButton } from './components/TabButton';
 import { ActivePill } from './components/ActivePill';
 import { Modal } from './components/Modal';
 import { DevTests } from './components/DevTests';
-import { sampleCourse } from './data/sampleCourse';
+import { sampleCategories } from './data/sampleCategories';
+import type { Category, Course, Exercise } from './types';
 
 export default function RehabMiniApp() {
   const envReady = useEnvReady();
   const ls = safeLocalStorage();
 
   const [tab, setTab] = useState<'home' | 'shop' | 'profile'>('home');
-  const [viewer, setViewer] = useState<{ id: string; title: string } | null>(null);
+  const [viewerCourse, setViewerCourse] = useState<Course | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
+  const [selectedCourse, setSelectedCourse] = useState<Course | null>(null);
   const [paywallOpen, setPaywallOpen] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
 
@@ -58,12 +60,7 @@ export default function RehabMiniApp() {
     { id: 'spine', title: 'Healthy Back', text: '10‑min daily plan', cta: 'Explore', color: 'bg-gradient-to-r from-emerald-600 to-teal-700' },
   ]), []);
 
-  const lessons = useMemo(() => ([
-    { id: 'l1', title: 'Breathing & Mobility (Free)', thumb: placeholderThumb('#2563eb'), free: true },
-    { id: 'l2', title: 'Neck Relief', thumb: placeholderThumb('#7c3aed'), free: false },
-    { id: 'l3', title: 'Lower Back Care', thumb: placeholderThumb('#d97706'), free: false },
-    { id: 'l4', title: 'Shoulder Mobility', thumb: placeholderThumb('#059669'), free: false },
-  ]), []);
+  const categories = useMemo(() => sampleCategories, []);
 
   const products = useMemo(() => ([
     { id: 'p1', title: 'Resistance Band — Small', price: 19.9, image: placeholderProduct('S') },
@@ -73,18 +70,12 @@ export default function RehabMiniApp() {
 
   const [bannerIdx, setBannerIdx] = useState(0);
   useEffect(() => {
-    if (paywallOpen || viewer) return;
+    if (paywallOpen || viewerCourse) return;
     const t = setInterval(() => setBannerIdx(i => (i + 1) % banners.length), 4000);
     return () => clearInterval(t);
-  }, [paywallOpen, viewer, banners.length]);
+  }, [paywallOpen, viewerCourse, banners.length]);
 
   const ping = (msg: string) => { setToast(msg); setTimeout(() => setToast(null), 1300); };
-
-  const handleOpenLesson = (l: any) => {
-    if (!l.free && !subActive) { setPaywallOpen(true); return; }
-    setViewer({ id: l.id, title: l.title });
-    if (envReady) try { window.localStorage.setItem('lastLesson', JSON.stringify(l)); } catch {}
-  };
 
   const addToCart = (p: any) => {
     setCart(prev => {
@@ -95,6 +86,16 @@ export default function RehabMiniApp() {
     ping('Added to cart');
   };
 
+  const startExercise = (ex: Exercise) => {
+    if (!selectedCourse) return;
+    const single: Course = {
+      id: `${selectedCourse.id}-${ex.id}`,
+      title: ex.title,
+      laps: [{ id: ex.id, title: ex.title, exercises: [ex] }],
+    };
+    setViewerCourse(single);
+  };
+
   return (
     <div
       className="w-full min-h-[100dvh] bg-neutral-950 text-gray-100 flex flex-col font-sans"
@@ -103,43 +104,88 @@ export default function RehabMiniApp() {
       <main className="flex-1 pb-20 animate-fadeIn">
         {tab === 'home' && (
           <div>
-            <div className="px-4 pt-4">
-              <div className="flex gap-3 overflow-x-auto snap-x snap-mandatory no-scrollbar">
-                {banners.map((b, idx) => (
-                  <article key={b.id} className={`min-w-[85%] ${b.color} text-white rounded-3xl p-5 snap-start shadow-lg hover:scale-[1.02] transition-transform`} onClick={() => (idx === 0 ? setPaywallOpen(true) : setBannerIdx(idx))}>
-                    <h3 className="text-xl font-bold tracking-tight">{b.title}</h3>
-                    <p className="text-sm opacity-90 mt-1">{b.text}</p>
-                    <button className="mt-4 px-5 py-2 bg-white/90 text-gray-900 rounded-xl text-sm font-semibold shadow-sm hover:bg-white transition">{b.cta}</button>
-                  </article>
-                ))}
+            {!selectedCategory && !selectedCourse && (
+              <>
+                <div className="px-4 pt-4">
+                  <div className="flex gap-3 overflow-x-auto snap-x snap-mandatory no-scrollbar">
+                    {banners.map((b, idx) => (
+                      <article key={b.id} className={`min-w-[85%] ${b.color} text-white rounded-3xl p-5 snap-start shadow-lg hover:scale-[1.02] transition-transform`} onClick={() => (idx === 0 ? setPaywallOpen(true) : setBannerIdx(idx))}>
+                        <h3 className="text-xl font-bold tracking-tight">{b.title}</h3>
+                        <p className="text-sm opacity-90 mt-1">{b.text}</p>
+                        <button className="mt-4 px-5 py-2 bg-white/90 text-gray-900 rounded-xl text-sm font-semibold shadow-sm hover:bg-white transition">{b.cta}</button>
+                      </article>
+                    ))}
+                  </div>
+                  <div className="flex gap-2 mt-3 justify-center">
+                    {banners.map((_, i) => (
+                      <span key={i} className={`w-2 h-2 rounded-full cursor-pointer ${bannerIdx === i ? 'bg-blue-400' : 'bg-gray-600'}`} onClick={() => setBannerIdx(i)} />
+                    ))}
+                  </div>
+                </div>
+                <section className="px-4 mt-6">
+                  <h4 className="text-lg font-bold mb-3">Категории</h4>
+                  <div className="grid gap-3">
+                    {categories.map((cat) => (
+                      <button key={cat.id} className="relative text-left group active:scale-[.99] transition flex items-center gap-3 p-4 rounded-2xl bg-neutral-900 border border-neutral-800" onClick={() => setSelectedCategory(cat)}>
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm font-medium leading-snug line-clamp-2">{cat.title}</div>
+                        </div>
+                        <span className="text-gray-500">›</span>
+                      </button>
+                    ))}
+                  </div>
+                </section>
+              </>
+            )}
+            {selectedCategory && !selectedCourse && (
+              <div className="px-4 pt-4">
+                <button className="mb-4 text-sm text-gray-400" onClick={() => setSelectedCategory(null)}>← Back</button>
+                <h4 className="text-lg font-bold mb-3">{selectedCategory.title}</h4>
+                <div className="grid gap-3">
+                  {selectedCategory.courses.map((c) => (
+                    <button key={c.id} className="relative text-left group active:scale-[.99] transition flex items-center gap-3 p-4 rounded-2xl bg-neutral-900 border border-neutral-800" onClick={() => setSelectedCourse(c)}>
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium leading-snug line-clamp-2">{c.title}</div>
+                      </div>
+                      <span className="text-gray-500">›</span>
+                    </button>
+                  ))}
+                </div>
               </div>
-              <div className="flex gap-2 mt-3 justify-center">
-                {banners.map((_, i) => (
-                  <span key={i} className={`w-2 h-2 rounded-full cursor-pointer ${bannerIdx === i ? 'bg-blue-400' : 'bg-gray-600'}`} onClick={() => setBannerIdx(i)} />
-                ))}
-              </div>
-            </div>
-
-            <section className="px-4 mt-6">
-              <h4 className="text-lg font-bold mb-2">Continue watching</h4>
-              <ContinueWatching onOpen={(l: any) => handleOpenLesson(l)} envReady={envReady} />
-
-              <h4 className="text-lg font-bold mt-5 mb-3">Starter Course</h4>
-              <div className="grid gap-3">
-                {lessons.map((l) => (
-                  <button key={l.id} className="relative text-left group active:scale-[.99] transition flex items-center gap-3 p-2 rounded-2xl bg-neutral-900 border border-neutral-800" onClick={() => handleOpenLesson(l)}>
-                    <img src={l.thumb} alt="" className={`w-28 aspect-video rounded-xl object-cover ${!l.free && !subActive ? 'blur-[3px] brightness-90' : ''}`} />
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium leading-snug line-clamp-2">{l.title}</div>
-                      {!l.free && !subActive && (
-                        <div className="mt-1 text-xs text-gray-400 flex items-center gap-1">🔒 <span>Subscribe to unlock</span></div>
-                      )}
+            )}
+            {selectedCourse && (
+              <div className="px-4 pt-4">
+                <button className="mb-4 text-sm text-gray-400" onClick={() => setSelectedCourse(null)}>← Back</button>
+                <button
+                  className="w-full mb-4 px-4 py-3 bg-blue-600 text-white rounded-xl text-sm font-medium hover:bg-blue-500 transition"
+                  onClick={() => setViewerCourse(selectedCourse)}
+                >
+                  Start workout
+                </button>
+                <h4 className="text-lg font-bold mb-3">{selectedCourse.title}</h4>
+                <div className="grid gap-4">
+                  {selectedCourse.laps.map((l) => (
+                    <div key={l.id} className="rounded-2xl bg-neutral-900 border border-neutral-800 p-4">
+                      <div className="font-medium mb-2">{l.title}{l.rounds ? ` ×${l.rounds}` : ''}</div>
+                      <div className="grid gap-2">
+                        {l.exercises.map((e) => (
+                          <button
+                            key={e.id}
+                            className="w-full text-left p-3 rounded-xl bg-neutral-800 hover:bg-neutral-700 flex items-center justify-between"
+                            onClick={() => startExercise(e)}
+                          >
+                            <span className="text-sm">
+                              {e.title} — {e.mode === 'time' ? `${e.durationSec}s` : `${e.reps} reps`}
+                            </span>
+                            <span className="text-blue-400 text-sm">▶</span>
+                          </button>
+                        ))}
+                      </div>
                     </div>
-                    <span className="text-gray-500">›</span>
-                  </button>
-                ))}
+                  ))}
+                </div>
               </div>
-            </section>
+            )}
           </div>
         )}
 
@@ -214,8 +260,8 @@ export default function RehabMiniApp() {
         </div>
       </nav>
 
-      {viewer && (
-        <VideoScreen course={sampleCourse} title={viewer.title} onClose={() => setViewer(null)} />
+      {viewerCourse && (
+        <VideoScreen course={viewerCourse} title={viewerCourse.title} onClose={() => setViewerCourse(null)} />
       )}
 
       <Modal open={paywallOpen} onClose={() => setPaywallOpen(false)}>

--- a/src/components/VideoScreen.tsx
+++ b/src/components/VideoScreen.tsx
@@ -1,12 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useSequenceRunner } from '../hooks/useSequenceRunner';
 import type { Course } from '../types';
 import { EmbedPlayer } from './EmbedPlayer';
 
 export function VideoScreen({ course, onClose, title }: { course: Course; onClose: () => void; title?: string }) {
   const s = useSequenceRunner(course);
-
-  useEffect(() => { if (s.mode === 'rest') s.next(); }, [s.mode]);
 
   const [playTick, setPlayTick] = useState(0);
   const [muted, setMuted] = useState(true);
@@ -35,6 +33,15 @@ export function VideoScreen({ course, onClose, title }: { course: Course; onClos
         muted={muted}
         showControls={false}
       />
+      {s.mode === 'rest' && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="bg-black/70 text-white px-4 py-3 rounded-xl text-center">
+            <div>Rest</div>
+            <div className="text-xl tabular-nums">{s.remaining ?? 0}s</div>
+            <button className="mt-2 px-3 py-1 bg-white/20 rounded" onClick={s.skipRest}>Skip</button>
+          </div>
+        </div>
+      )}
       <div className="absolute left-4" style={{ top: topSafe }}>
         <button className="px-4 py-2 bg-black/60 text-white rounded-lg" onClick={onClose}>Exit</button>
       </div>

--- a/src/data/sampleCategories.ts
+++ b/src/data/sampleCategories.ts
@@ -1,0 +1,9 @@
+import type { Category } from '../types';
+import { sampleCourse } from './sampleCourse';
+
+export const sampleCategories: Category[] = [
+  { id: 'strength', title: 'Силовые тренировки', courses: [sampleCourse] },
+  { id: 'posture', title: 'Осанка', courses: [] },
+  { id: 'recovery', title: 'Восстановление после операции', courses: [] },
+  { id: 'acl', title: 'Реабилитация после ПКС', courses: [] },
+];

--- a/src/data/sampleCourse.ts
+++ b/src/data/sampleCourse.ts
@@ -22,7 +22,8 @@ export const sampleCourse: Course = {
     {
       id: 'main',
       title: 'Main set',
-      repeat: 2,
+      rounds: 2,
+      restBetweenSec: 30,
       exercises: [
         { id: 'plank', title: 'Elbow Plank', video: muxVideos[2], mode: 'time', durationSec: 45, restSec: 20, cues: [{ atSec: 10, text: 'Engage core', tts: true }, { atSec: 35, text: '10 seconds', tts: true }] },
         { id: 'bird', title: 'Bird Dog', video: muxVideos[3], mode: 'reps', reps: 10, restSec: 15 }

--- a/src/hooks/useSequenceRunner.ts
+++ b/src/hooks/useSequenceRunner.ts
@@ -4,8 +4,10 @@ import type { Course } from '../types';
 export function useSequenceRunner(course: Course) {
   const [lapIdx, setLapIdx] = useState(0);
   const [exIdx, setExIdx] = useState(0);
+  const [roundIdx, setRoundIdx] = useState(0);
   const [mode, setMode] = useState<'playing' | 'rest' | 'paused' | 'complete'>('paused');
   const [remaining, setRemaining] = useState<number | null>(null);
+  const [pending, setPending] = useState<'exercise' | 'round' | 'lap' | 'complete' | null>(null);
 
   const lap = course.laps[lapIdx];
   const ex = lap?.exercises[exIdx];
@@ -17,25 +19,92 @@ export function useSequenceRunner(course: Course) {
     const t = setInterval(() => setRemaining(v => (v! > 0 ? v! - 1 : 0)), 1000);
     return () => clearInterval(t);
   }, [mode, ex, remaining]);
-  useEffect(() => { if (ex?.mode === 'time' && remaining === 0) next(); }, [remaining]);
+
+  useEffect(() => {
+    if (mode !== 'rest' || remaining == null) return;
+    const t = setInterval(() => setRemaining(v => (v! > 0 ? v! - 1 : 0)), 1000);
+    return () => clearInterval(t);
+  }, [mode, remaining]);
+
+  useEffect(() => {
+    if (mode === 'playing' && ex?.mode === 'time' && remaining === 0) next();
+    if (mode === 'rest' && remaining === 0) next();
+  }, [mode, ex?.id, remaining]);
 
   function play() { setMode('playing'); }
   function pause() { setMode('paused'); }
-  function skipRest() { if (mode === 'rest') { setMode('playing'); setRemaining(null); next(); } }
+  function skipRest() { if (mode === 'rest') { setRemaining(0); } }
   function addRest(delta: number) { if (mode === 'rest') setRemaining(v => Math.max(0, (v ?? 0) + delta)); }
   function resetTimers() { setRemaining(null); }
 
   function next() {
-    const cur = ex;
-    if (cur?.restSec && mode !== 'rest') { setMode('rest'); setRemaining(cur.restSec); return; }
-    if (exIdx + 1 < (lap?.exercises.length || 0)) { setExIdx(exIdx + 1); resetTimers(); setMode('playing'); return; }
-    if (lapIdx + 1 < course.laps.length) { setLapIdx(lapIdx + 1); setExIdx(0); resetTimers(); setMode('playing'); return; }
+    if (mode === 'rest') {
+      setMode('playing');
+      resetTimers();
+      if (pending === 'exercise') setExIdx(i => i + 1);
+      else if (pending === 'round') { setRoundIdx(r => r + 1); setExIdx(0); }
+      else if (pending === 'lap') { setLapIdx(l => l + 1); setRoundIdx(0); setExIdx(0); }
+      else if (pending === 'complete') setMode('complete');
+      setPending(null);
+      return;
+    }
+
+    const curLap = lap;
+    const curEx = ex;
+    if (!curLap || !curEx) { setMode('complete'); return; }
+
+    const nextExIdx = exIdx + 1;
+    if (curEx.restSec) {
+      setMode('rest');
+      setRemaining(curEx.restSec);
+      if (nextExIdx < curLap.exercises.length) setPending('exercise');
+      else if (roundIdx + 1 < (curLap.rounds || 1)) setPending('round');
+      else if (lapIdx + 1 < course.laps.length) setPending('lap');
+      else setPending('complete');
+      return;
+    }
+
+    if (nextExIdx < curLap.exercises.length) {
+      setExIdx(nextExIdx);
+      resetTimers();
+      return;
+    }
+
+    if (roundIdx + 1 < (curLap.rounds || 1)) {
+      if (curLap.restBetweenSec) {
+        setMode('rest');
+        setRemaining(curLap.restBetweenSec);
+        setPending('round');
+      } else {
+        setRoundIdx(r => r + 1);
+        setExIdx(0);
+        resetTimers();
+      }
+      return;
+    }
+
+    if (lapIdx + 1 < course.laps.length) {
+      setLapIdx(l => l + 1);
+      setRoundIdx(0);
+      setExIdx(0);
+      resetTimers();
+      return;
+    }
+
     setMode('complete');
   }
+
   function prev() {
-    if (exIdx > 0) { setExIdx(exIdx - 1); resetTimers(); return; }
-    if (lapIdx > 0) { const prevLap = course.laps[lapIdx - 1]; setLapIdx(lapIdx - 1); setExIdx(prevLap.exercises.length - 1); resetTimers(); }
+    if (exIdx > 0) { setExIdx(i => i - 1); resetTimers(); return; }
+    if (roundIdx > 0) { setRoundIdx(r => r - 1); setExIdx(lap.exercises.length - 1); resetTimers(); return; }
+    if (lapIdx > 0) {
+      const prevLap = course.laps[lapIdx - 1];
+      setLapIdx(lapIdx - 1);
+      setRoundIdx((prevLap.rounds || 1) - 1);
+      setExIdx(prevLap.exercises.length - 1);
+      resetTimers();
+    }
   }
 
-  return { lapIdx, exIdx, lap, ex, mode, remaining, play, pause, next, prev, skipRest, addRest };
+  return { lapIdx, exIdx, roundIdx, lap, ex, mode, remaining, play, pause, next, prev, skipRest, addRest };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,14 @@ export type Exercise = {
   cues?: Cue[];
 };
 
-export type Lap = { id: string; title: string; exercises: Exercise[]; repeat?: number };
+export type Lap = {
+  id: string;
+  title: string;
+  exercises: Exercise[];
+  rounds?: number;
+  restBetweenSec?: number;
+};
 
 export type Course = { id: string; title: string; laps: Lap[] };
+
+export type Category = { id: string; title: string; courses: Course[] };


### PR DESCRIPTION
## Summary
- Introduce Category type and extend course laps with round counts and rest between rounds
- Add sample categories dataset and update sample course to use rounds
- Implement round-aware sequence runner and rest overlay in video screen
- Add category and course navigation to the home tab
- Redesign exercise list with grouped complexes and per-exercise start controls

## Testing
- `npm test`
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898764ae08083218c3be3776809a47e