### PR TITLE
feat: add reusable video loader

### DIFF
--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from 'react';
+
+export interface LoaderProps {
+  active: boolean;
+  mode?: 'global' | 'local';
+}
+
+// Reusable loader following Codex design guidelines.
+// Shows with a small delay and keeps visible for a minimum duration
+// to avoid flickering.
+export function Loader({ active, mode = 'local' }: LoaderProps) {
+  const [visible, setVisible] = useState(false);
+  const showTimer = useRef<NodeJS.Timeout | null>(null);
+  const hideTimer = useRef<NodeJS.Timeout | null>(null);
+  const minVisibleUntil = useRef<number>(0);
+
+  useEffect(() => {
+    if (active) {
+      if (hideTimer.current) {
+        clearTimeout(hideTimer.current);
+        hideTimer.current = null;
+      }
+      if (!showTimer.current) {
+        showTimer.current = setTimeout(() => {
+          setVisible(true);
+          minVisibleUntil.current = Date.now() + 300; // minimum duration 300ms
+          showTimer.current = null;
+        }, 150); // delay before showing 150ms
+      }
+    } else {
+      if (showTimer.current) {
+        clearTimeout(showTimer.current);
+        showTimer.current = null;
+      }
+      const remaining = minVisibleUntil.current - Date.now();
+      if (remaining > 0) {
+        hideTimer.current = setTimeout(() => {
+          setVisible(false);
+          hideTimer.current = null;
+        }, remaining);
+      } else {
+        setVisible(false);
+      }
+    }
+  }, [active]);
+
+  useEffect(() => {
+    return () => {
+      if (showTimer.current) clearTimeout(showTimer.current);
+      if (hideTimer.current) clearTimeout(hideTimer.current);
+    };
+  }, []);
+
+  if (!visible) return null;
+
+  const base = mode === 'global' ? 'fixed inset-0 z-50' : 'absolute inset-0';
+
+  return (
+    <div className={`${base} flex items-center justify-center bg-black/50 transition-opacity`}>
+      <div className="h-10 w-10 border-4 border-white/30 border-t-white rounded-full animate-spin" />
+    </div>
+  );
+}
+
+export default Loader;
+


### PR DESCRIPTION
## Summary
- add generic Loader component supporting global and local modes
- show loader and retry overlay in PlaylistPlayer based on buffering and errors

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898ba9385e08321b0c3b2afc6ae8fdd