### PR TITLE
Add Node.js API backend with CRUD endpoints

### DIFF
--- a/pages/api/categories/[id].ts
+++ b/pages/api/categories/[id].ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { categories } from '../../../src/backend/data';
+import type { Category } from '../../../src/types';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  const idx = categories.findIndex(c => c.id === id);
+
+  if (idx === -1) {
+    res.status(404).json({ message: 'Not found' });
+    return;
+  }
+
+  switch (req.method) {
+    case 'GET':
+      res.status(200).json(categories[idx]);
+      break;
+    case 'PUT':
+      categories[idx] = req.body as Category;
+      res.status(200).json(categories[idx]);
+      break;
+    case 'DELETE':
+      const deleted = categories.splice(idx, 1);
+      res.status(200).json(deleted[0]);
+      break;
+    default:
+      res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
+      res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/api/categories/index.ts
+++ b/pages/api/categories/index.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { categories } from '../../../src/backend/data';
+import type { Category } from '../../../src/types';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  switch (req.method) {
+    case 'GET':
+      res.status(200).json(categories);
+      break;
+    case 'POST':
+      const category: Category = req.body;
+      categories.push(category);
+      res.status(201).json(category);
+      break;
+    default:
+      res.setHeader('Allow', ['GET', 'POST']);
+      res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/api/courses/[id].ts
+++ b/pages/api/courses/[id].ts
@@ -1,0 +1,40 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { categories, courses } from '../../../src/backend/data';
+import type { Course } from '../../../src/types';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  const idx = courses.findIndex(c => c.id === id);
+
+  if (idx === -1) {
+    res.status(404).json({ message: 'Not found' });
+    return;
+  }
+
+  switch (req.method) {
+    case 'GET':
+      res.status(200).json(courses[idx]);
+      break;
+    case 'PUT':
+      const updated = req.body as Course;
+      courses[idx] = updated;
+      categories.forEach(cat => {
+        const ci = cat.courses.findIndex(c => c.id === id);
+        if (ci !== -1) {
+          cat.courses[ci] = updated;
+        }
+      });
+      res.status(200).json(updated);
+      break;
+    case 'DELETE':
+      const removed = courses.splice(idx, 1)[0];
+      categories.forEach(cat => {
+        cat.courses = cat.courses.filter(c => c.id !== id);
+      });
+      res.status(200).json(removed);
+      break;
+    default:
+      res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
+      res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/api/courses/index.ts
+++ b/pages/api/courses/index.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { categories, courses } from '../../../src/backend/data';
+import type { Course } from '../../../src/types';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  switch (req.method) {
+    case 'GET':
+      res.status(200).json(courses);
+      break;
+    case 'POST':
+      const { categoryId, course } = req.body as { categoryId: string; course: Course };
+      courses.push(course);
+      const cat = categories.find(c => c.id === categoryId);
+      if (cat) {
+        cat.courses.push(course);
+      }
+      res.status(201).json(course);
+      break;
+    default:
+      res.setHeader('Allow', ['GET', 'POST']);
+      res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/api/videos/[id].ts
+++ b/pages/api/videos/[id].ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { videos } from '../../../src/backend/data';
+import type { Video } from '../../../src/types';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  const idx = videos.findIndex(v => v.id === id);
+
+  if (idx === -1) {
+    res.status(404).json({ message: 'Not found' });
+    return;
+  }
+
+  switch (req.method) {
+    case 'GET':
+      res.status(200).json(videos[idx]);
+      break;
+    case 'PUT':
+      videos[idx] = req.body as Video;
+      res.status(200).json(videos[idx]);
+      break;
+    case 'DELETE':
+      const removed = videos.splice(idx, 1)[0];
+      res.status(200).json(removed);
+      break;
+    default:
+      res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
+      res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/pages/api/videos/index.ts
+++ b/pages/api/videos/index.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { videos } from '../../../src/backend/data';
+import type { Video } from '../../../src/types';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  switch (req.method) {
+    case 'GET':
+      res.status(200).json(videos);
+      break;
+    case 'POST':
+      const video: Video = req.body;
+      videos.push(video);
+      res.status(201).json(video);
+      break;
+    default:
+      res.setHeader('Allow', ['GET', 'POST']);
+      res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}

--- a/src/backend/data.ts
+++ b/src/backend/data.ts
@@ -1,0 +1,13 @@
+import type { Category, Course, Video } from '../types';
+import { sampleCategories } from '../data/sampleCategories';
+import { muxVideos } from '../data/sampleCourse';
+
+export const categories: Category[] = [...sampleCategories];
+
+export const courses: Course[] = sampleCategories.flatMap(c => c.courses);
+
+export const videos: Video[] = muxVideos.map((url, i) => ({
+  id: `video-${i + 1}`,
+  title: `Sample Video ${i + 1}`,
+  url,
+}));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,12 @@
 export type Cue = { atSec: number; text: string; tts?: boolean };
 
+export type Video = {
+  id: string;
+  title: string;
+  url: string;
+  thumbnail?: string;
+};
+
 export type Exercise = {
   id: string;
   title: string;


### PR DESCRIPTION
## Summary
- add shared Video type and backend data store
- implement Next.js API routes for categories, courses, and videos CRUD
- include sample in-memory data for categories, courses, and videos

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a07e6c370832199f160618be9e7c9