### PR TITLE
Add admin panel with login and CRUD features

### DIFF
--- a/pages/admin/categories/[id].tsx
+++ b/pages/admin/categories/[id].tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import type { Category, Course } from '../../../src/types';
+
+const emptyCourse = { id: '', title: '' };
+
+export default function CategoryDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [category, setCategory] = useState<Category | null>(null);
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [form, setForm] = useState(emptyCourse);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editingCourse, setEditingCourse] = useState<Course | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
+      router.replace('/admin/login');
+      return;
+    }
+    fetchCategory();
+  }, [id]);
+
+  const fetchCategory = async () => {
+    const res = await fetch(`/api/categories/${id}`);
+    const data = await res.json();
+    setCategory(data);
+    setCourses(data.courses || []);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!category) return;
+    if (editId && editingCourse) {
+      const updated: Course = { ...editingCourse, title: form.title };
+      await fetch(`/api/courses/${editId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updated),
+      });
+    } else {
+      const newCourse: Course = {
+        id: form.id,
+        title: form.title,
+        laps: [{ id: 'main', title: 'Main', exercises: [] }],
+      };
+      await fetch('/api/courses', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ categoryId: category.id, course: newCourse }),
+      });
+    }
+    setForm(emptyCourse);
+    setEditId(null);
+    setEditingCourse(null);
+    fetchCategory();
+  };
+
+  const handleEdit = (course: Course) => {
+    setEditId(course.id);
+    setEditingCourse(course);
+    setForm({ id: course.id, title: course.title });
+  };
+
+  const handleDelete = async (courseId: string) => {
+    if (!confirm('Delete?')) return;
+    await fetch(`/api/courses/${courseId}`, { method: 'DELETE' });
+    fetchCategory();
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <button onClick={() => router.push('/admin')}>Back</button>
+      <h1>Category: {category?.title}</h1>
+      <ul>
+        {courses.map((c) => (
+          <li key={c.id}>
+            {c.title} ({c.id}){' '}
+            <button onClick={() => handleEdit(c)}>Edit</button>
+            <button onClick={() => handleDelete(c.id)}>Delete</button>
+            <Link href={`/admin/courses/${c.id}`} style={{ marginLeft: 10 }}>
+              Exercises
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <h2 style={{ marginTop: 30 }}>{editId ? 'Edit' : 'Add'} Training</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={form.id}
+          onChange={(e) => setForm({ ...form, id: e.target.value })}
+          placeholder="id"
+          disabled={!!editId}
+        />
+        <input
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          placeholder="title"
+        />
+        <button type="submit">{editId ? 'Update' : 'Create'}</button>
+      </form>
+    </div>
+  );
+}

--- a/pages/admin/courses/[id].tsx
+++ b/pages/admin/courses/[id].tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import type { Course, Exercise } from '../../../src/types';
+
+const blankExercise: Exercise = {
+  id: '',
+  title: '',
+  video: '',
+  mode: 'time',
+  durationSec: 30,
+  reps: 0,
+};
+
+export default function CourseDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [course, setCourse] = useState<Course | null>(null);
+  const [form, setForm] = useState<Exercise>(blankExercise);
+  const [editIdx, setEditIdx] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
+      router.replace('/admin/login');
+      return;
+    }
+    fetchCourse();
+  }, [id]);
+
+  const fetchCourse = async () => {
+    const res = await fetch(`/api/courses/${id}`);
+    const data = await res.json();
+    if (!data.laps || !data.laps.length) {
+      data.laps = [{ id: 'main', title: 'Main', exercises: [] }];
+    }
+    setCourse(data);
+  };
+
+  const saveCourse = async (updated: Course) => {
+    await fetch(`/api/courses/${updated.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updated),
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!course) return;
+    const lap = course.laps[0];
+    const exercises = [...lap.exercises];
+    if (editIdx !== null) {
+      exercises[editIdx] = form;
+    } else {
+      exercises.push(form);
+    }
+    const updated: Course = { ...course, laps: [{ ...lap, exercises }] };
+    await saveCourse(updated);
+    setEditIdx(null);
+    setForm(blankExercise);
+    fetchCourse();
+  };
+
+  const handleEdit = (idx: number, ex: Exercise) => {
+    setEditIdx(idx);
+    setForm(ex);
+  };
+
+  const handleDelete = async (idx: number) => {
+    if (!course) return;
+    const lap = course.laps[0];
+    const exercises = lap.exercises.filter((_, i) => i !== idx);
+    const updated: Course = { ...course, laps: [{ ...lap, exercises }] };
+    await saveCourse(updated);
+    fetchCourse();
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <button onClick={() => router.back()}>Back</button>
+      <h1>Training: {course?.title}</h1>
+      <ul>
+        {course?.laps[0]?.exercises.map((ex: Exercise, idx: number) => (
+          <li key={ex.id}>
+            {ex.title} ({ex.mode})
+            <button onClick={() => handleEdit(idx, ex)}>Edit</button>
+            <button onClick={() => handleDelete(idx)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+      <h2 style={{ marginTop: 30 }}>{editIdx !== null ? 'Edit' : 'Add'} Exercise</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={form.id}
+          onChange={(e) => setForm({ ...form, id: e.target.value })}
+          placeholder="id"
+          disabled={editIdx !== null}
+        />
+        <input
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          placeholder="title"
+        />
+        <input
+          value={form.video}
+          onChange={(e) => setForm({ ...form, video: e.target.value })}
+          placeholder="Mux video URL"
+        />
+        <select
+          value={form.mode}
+          onChange={(e) =>
+            setForm({ ...form, mode: e.target.value as Exercise['mode'] })
+          }
+        >
+          <option value="time">time</option>
+          <option value="reps">reps</option>
+          <option value="demo">demo</option>
+        </select>
+        {form.mode === 'time' && (
+          <input
+            type="number"
+            value={form.durationSec || ''}
+            onChange={(e) =>
+              setForm({ ...form, durationSec: Number(e.target.value) })
+            }
+            placeholder="durationSec"
+          />
+        )}
+        {form.mode === 'reps' && (
+          <input
+            type="number"
+            value={form.reps || ''}
+            onChange={(e) => setForm({ ...form, reps: Number(e.target.value) })}
+            placeholder="reps"
+          />
+        )}
+        <input
+          type="number"
+          value={form.restSec || ''}
+          onChange={(e) => setForm({ ...form, restSec: Number(e.target.value) })}
+          placeholder="restSec"
+        />
+        <button type="submit">{editIdx !== null ? 'Update' : 'Create'}</button>
+      </form>
+    </div>
+  );
+}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import type { Category } from '../../src/types';
+
+const emptyForm = { id: '', title: '' };
+
+export default function AdminCategories() {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [form, setForm] = useState(emptyForm);
+  const [editId, setEditId] = useState<string | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
+      router.replace('/admin/login');
+      return;
+    }
+    fetchCategories();
+  }, []);
+
+  const fetchCategories = async () => {
+    const res = await fetch('/api/categories');
+    const data = await res.json();
+    setCategories(data);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (editId) {
+      await fetch(`/api/categories/${editId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+    } else {
+      await fetch('/api/categories', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+    }
+    setForm(emptyForm);
+    setEditId(null);
+    fetchCategories();
+  };
+
+  const handleEdit = (cat: Category) => {
+    setEditId(cat.id);
+    setForm({ id: cat.id, title: cat.title });
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete?')) return;
+    await fetch(`/api/categories/${id}`, { method: 'DELETE' });
+    fetchCategories();
+  };
+
+  const logout = () => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem('admin-token');
+    }
+    router.replace('/admin/login');
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Admin Panel</h1>
+      <nav style={{ marginBottom: 20 }}>
+        <Link href="/admin">Categories</Link> |{' '}
+        <Link href="/admin/videos">Videos</Link>
+        <button style={{ marginLeft: 20 }} onClick={logout}>Logout</button>
+      </nav>
+      <ul>
+        {categories.map((cat) => (
+          <li key={cat.id}>
+            {cat.title} ({cat.id}){' '}
+            <button onClick={() => handleEdit(cat)}>Edit</button>
+            <button onClick={() => handleDelete(cat.id)}>Delete</button>
+            <Link href={`/admin/categories/${cat.id}`} style={{ marginLeft: 10 }}>
+              Trainings
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <h2 style={{ marginTop: 30 }}>{editId ? 'Edit' : 'Add'} Category</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={form.id}
+          onChange={(e) => setForm({ ...form, id: e.target.value })}
+          placeholder="id"
+          disabled={!!editId}
+        />
+        <input
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          placeholder="title"
+        />
+        <button type="submit">{editId ? 'Update' : 'Create'}</button>
+      </form>
+    </div>
+  );
+}

--- a/pages/admin/login.tsx
+++ b/pages/admin/login.tsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function AdminLogin() {
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      if (window.localStorage.getItem('admin-token')) {
+        router.replace('/admin');
+      }
+    }
+  }, [router]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const pwd = process.env.NEXT_PUBLIC_ADMIN_PASSWORD || 'admin';
+    if (password === pwd) {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem('admin-token', '1');
+      }
+      router.replace('/admin');
+    } else {
+      alert('Invalid password');
+    }
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Admin Login</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+        <button type="submit">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/pages/admin/videos/index.tsx
+++ b/pages/admin/videos/index.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import type { Video } from '../../../src/types';
+
+const emptyVideo: Video = { id: '', title: '', url: '' };
+
+export default function AdminVideos() {
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [form, setForm] = useState<Video>(emptyVideo);
+  const [editId, setEditId] = useState<string | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
+      router.replace('/admin/login');
+      return;
+    }
+    fetchVideos();
+  }, []);
+
+  const fetchVideos = async () => {
+    const res = await fetch('/api/videos');
+    const data = await res.json();
+    setVideos(data);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (editId) {
+      await fetch(`/api/videos/${editId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+    } else {
+      await fetch('/api/videos', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+    }
+    setForm(emptyVideo);
+    setEditId(null);
+    fetchVideos();
+  };
+
+  const handleEdit = (v: Video) => {
+    setEditId(v.id);
+    setForm(v);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete?')) return;
+    await fetch(`/api/videos/${id}`, { method: 'DELETE' });
+    fetchVideos();
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <button onClick={() => router.push('/admin')}>Back</button>
+      <h1>Videos</h1>
+      <ul>
+        {videos.map((v) => (
+          <li key={v.id}>
+            {v.title} ({v.id})
+            <button onClick={() => handleEdit(v)}>Edit</button>
+            <button onClick={() => handleDelete(v.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+      <h2 style={{ marginTop: 30 }}>{editId ? 'Edit' : 'Add'} Video</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={form.id}
+          onChange={(e) => setForm({ ...form, id: e.target.value })}
+          placeholder="id"
+          disabled={!!editId}
+        />
+        <input
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          placeholder="title"
+        />
+        <input
+          value={form.url}
+          onChange={(e) => setForm({ ...form, url: e.target.value })}
+          placeholder="Mux URL"
+        />
+        <button type="submit">{editId ? 'Update' : 'Create'}</button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin login page using localStorage token
- implement categories, courses, exercises, and video CRUD interfaces

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a52c5f2f48321bc31aab54432440e