### PR TITLE
Add scalable admin panel layout and navigation

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.module.css';

--- a/pages/admin/categories/[id].tsx
+++ b/pages/admin/categories/[id].tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import type { Category, Course } from '../../../src/types';
+import type { Category, Course } from 'src/types';
+import AdminLayout from 'src/components/admin/AdminLayout';
 
 const emptyCourse = { id: '', title: '' };
 
@@ -71,8 +72,8 @@ export default function CategoryDetail() {
   };
 
   return (
-    <div style={{ padding: 20 }}>
-      <button onClick={() => router.push('/admin')}>Back</button>
+    <AdminLayout>
+      <button onClick={() => router.push('/admin/categories')}>Back</button>
       <h1>Category: {category?.title}</h1>
       <ul>
         {courses.map((c) => (
@@ -101,6 +102,6 @@ export default function CategoryDetail() {
         />
         <button type="submit">{editId ? 'Update' : 'Create'}</button>
       </form>
-    </div>
+    </AdminLayout>
   );
 }

--- a/pages/admin/categories/index.tsx
+++ b/pages/admin/categories/index.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
-import type { Video } from 'src/types';
+import type { Category } from 'src/types';
 import AdminLayout from 'src/components/admin/AdminLayout';
 
-const emptyVideo: Video = { id: '', title: '', url: '' };
+const emptyForm = { id: '', title: '' };
 
-export default function AdminVideos() {
-  const [videos, setVideos] = useState<Video[]>([]);
-  const [form, setForm] = useState<Video>(emptyVideo);
+export default function AdminCategories() {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [form, setForm] = useState(emptyForm);
   const [editId, setEditId] = useState<string | null>(null);
   const router = useRouter();
 
@@ -16,59 +17,62 @@ export default function AdminVideos() {
       router.replace('/admin/login');
       return;
     }
-    fetchVideos();
+    fetchCategories();
   }, []);
 
-  const fetchVideos = async () => {
-    const res = await fetch('/api/videos');
+  const fetchCategories = async () => {
+    const res = await fetch('/api/categories');
     const data = await res.json();
-    setVideos(data);
+    setCategories(data);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (editId) {
-      await fetch(`/api/videos/${editId}`, {
+      await fetch(`/api/categories/${editId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form),
       });
     } else {
-      await fetch('/api/videos', {
+      await fetch('/api/categories', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form),
       });
     }
-    setForm(emptyVideo);
+    setForm(emptyForm);
     setEditId(null);
-    fetchVideos();
+    fetchCategories();
   };
 
-  const handleEdit = (v: Video) => {
-    setEditId(v.id);
-    setForm(v);
+  const handleEdit = (cat: Category) => {
+    setEditId(cat.id);
+    setForm({ id: cat.id, title: cat.title });
   };
 
   const handleDelete = async (id: string) => {
     if (!confirm('Delete?')) return;
-    await fetch(`/api/videos/${id}`, { method: 'DELETE' });
-    fetchVideos();
+    await fetch(`/api/categories/${id}`, { method: 'DELETE' });
+    fetchCategories();
   };
 
   return (
     <AdminLayout>
-      <h1>Videos</h1>
+      <h1>Categories</h1>
       <ul>
-        {videos.map((v) => (
-          <li key={v.id}>
-            {v.title} ({v.id})
-            <button onClick={() => handleEdit(v)}>Edit</button>
-            <button onClick={() => handleDelete(v.id)}>Delete</button>
+        {categories.map((cat) => (
+          <li key={cat.id}>
+            {cat.title} ({cat.id}){' '}
+            <button onClick={() => handleEdit(cat)}>Edit</button>
+            <button onClick={() => handleDelete(cat.id)}>Delete</button>
+            <Link href={`/admin/categories/${cat.id}`} style={{ marginLeft: 10 }}>
+              Trainings
+            </Link>
           </li>
         ))}
       </ul>
-      <h2 style={{ marginTop: 30 }}>{editId ? 'Edit' : 'Add'} Video</h2>
+      <h2 style={{ marginTop: 30 }}>{editId ? 'Edit' : 'Add'} Category</h2>
       <form onSubmit={handleSubmit}>
         <input
           value={form.id}
@@ -80,11 +84,6 @@ export default function AdminVideos() {
           value={form.title}
           onChange={(e) => setForm({ ...form, title: e.target.value })}
           placeholder="title"
-        />
-        <input
-          value={form.url}
-          onChange={(e) => setForm({ ...form, url: e.target.value })}
-          placeholder="Mux URL"
         />
         <button type="submit">{editId ? 'Update' : 'Create'}</button>
       </form>

--- a/pages/admin/complexes/index.tsx
+++ b/pages/admin/complexes/index.tsx
@@ -1,0 +1,10 @@
+import AdminLayout from 'src/components/admin/AdminLayout';
+
+export default function AdminComplexes() {
+  return (
+    <AdminLayout>
+      <h1>Complexes</h1>
+      <p>Complex management will be available soon.</p>
+    </AdminLayout>
+  );
+}

--- a/pages/admin/courses/[id].tsx
+++ b/pages/admin/courses/[id].tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import type { Course, Exercise } from '../../../src/types';
+import type { Course, Exercise } from 'src/types';
+import AdminLayout from 'src/components/admin/AdminLayout';
 
 const blankExercise: Exercise = {
   id: '',
@@ -76,7 +77,7 @@ export default function CourseDetail() {
   };
 
   return (
-    <div style={{ padding: 20 }}>
+    <AdminLayout>
       <button onClick={() => router.back()}>Back</button>
       <h1>Training: {course?.title}</h1>
       <ul>
@@ -142,6 +143,6 @@ export default function CourseDetail() {
         />
         <button type="submit">{editIdx !== null ? 'Update' : 'Create'}</button>
       </form>
-    </div>
+    </AdminLayout>
   );
 }

--- a/pages/admin/exercises/index.tsx
+++ b/pages/admin/exercises/index.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import type { Course, Exercise } from 'src/types';
+import AdminLayout from 'src/components/admin/AdminLayout';
+
+interface FlatExercise extends Exercise {
+  courseId: string;
+  courseTitle: string;
+}
+
+export default function AdminExercises() {
+  const [exercises, setExercises] = useState<FlatExercise[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
+      router.replace('/admin/login');
+      return;
+    }
+    fetchExercises();
+  }, []);
+
+  const fetchExercises = async () => {
+    const res = await fetch('/api/courses');
+    const data: Course[] = await res.json();
+    const flat: FlatExercise[] = [];
+    data.forEach((course) => {
+      course.laps[0]?.exercises.forEach((ex) => {
+        flat.push({ ...ex, courseId: course.id, courseTitle: course.title });
+      });
+    });
+    setExercises(flat);
+  };
+
+  return (
+    <AdminLayout>
+      <h1>Exercises</h1>
+      <ul>
+        {exercises.map((ex) => (
+          <li key={ex.id}>
+            {ex.title} – {ex.courseTitle}
+            <Link href={`/admin/courses/${ex.courseId}`} style={{ marginLeft: 10 }}>
+              Edit
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </AdminLayout>
+  );
+}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,103 +1,10 @@
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
-import type { Category } from '../../src/types';
+import AdminLayout from 'src/components/admin/AdminLayout';
 
-const emptyForm = { id: '', title: '' };
-
-export default function AdminCategories() {
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [form, setForm] = useState(emptyForm);
-  const [editId, setEditId] = useState<string | null>(null);
-  const router = useRouter();
-
-  useEffect(() => {
-    if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
-      router.replace('/admin/login');
-      return;
-    }
-    fetchCategories();
-  }, []);
-
-  const fetchCategories = async () => {
-    const res = await fetch('/api/categories');
-    const data = await res.json();
-    setCategories(data);
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (editId) {
-      await fetch(`/api/categories/${editId}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
-      });
-    } else {
-      await fetch('/api/categories', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
-      });
-    }
-    setForm(emptyForm);
-    setEditId(null);
-    fetchCategories();
-  };
-
-  const handleEdit = (cat: Category) => {
-    setEditId(cat.id);
-    setForm({ id: cat.id, title: cat.title });
-  };
-
-  const handleDelete = async (id: string) => {
-    if (!confirm('Delete?')) return;
-    await fetch(`/api/categories/${id}`, { method: 'DELETE' });
-    fetchCategories();
-  };
-
-  const logout = () => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.removeItem('admin-token');
-    }
-    router.replace('/admin/login');
-  };
-
+export default function AdminDashboard() {
   return (
-    <div style={{ padding: 20 }}>
-      <h1>Admin Panel</h1>
-      <nav style={{ marginBottom: 20 }}>
-        <Link href="/admin">Categories</Link> |{' '}
-        <Link href="/admin/videos">Videos</Link>
-        <button style={{ marginLeft: 20 }} onClick={logout}>Logout</button>
-      </nav>
-      <ul>
-        {categories.map((cat) => (
-          <li key={cat.id}>
-            {cat.title} ({cat.id}){' '}
-            <button onClick={() => handleEdit(cat)}>Edit</button>
-            <button onClick={() => handleDelete(cat.id)}>Delete</button>
-            <Link href={`/admin/categories/${cat.id}`} style={{ marginLeft: 10 }}>
-              Trainings
-            </Link>
-          </li>
-        ))}
-      </ul>
-      <h2 style={{ marginTop: 30 }}>{editId ? 'Edit' : 'Add'} Category</h2>
-      <form onSubmit={handleSubmit}>
-        <input
-          value={form.id}
-          onChange={(e) => setForm({ ...form, id: e.target.value })}
-          placeholder="id"
-          disabled={!!editId}
-        />
-        <input
-          value={form.title}
-          onChange={(e) => setForm({ ...form, title: e.target.value })}
-          placeholder="title"
-        />
-        <button type="submit">{editId ? 'Update' : 'Create'}</button>
-      </form>
-    </div>
+    <AdminLayout>
+      <h1>Dashboard</h1>
+      <p>Select a section from the menu to manage content.</p>
+    </AdminLayout>
   );
 }

--- a/pages/admin/trainings/index.tsx
+++ b/pages/admin/trainings/index.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import type { Course } from 'src/types';
+import AdminLayout from 'src/components/admin/AdminLayout';
+
+export default function AdminTrainings() {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
+      router.replace('/admin/login');
+      return;
+    }
+    fetchCourses();
+  }, []);
+
+  const fetchCourses = async () => {
+    const res = await fetch('/api/courses');
+    const data = await res.json();
+    setCourses(data);
+  };
+
+  return (
+    <AdminLayout>
+      <h1>Trainings</h1>
+      <ul>
+        {courses.map((c) => (
+          <li key={c.id}>
+            {c.title}
+            <Link href={`/admin/courses/${c.id}`} style={{ marginLeft: 10 }}>
+              Edit
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </AdminLayout>
+  );
+}

--- a/src/components/admin/AdminLayout.module.css
+++ b/src/components/admin/AdminLayout.module.css
@@ -1,0 +1,40 @@
+.container {
+  display: flex;
+  min-height: 100vh;
+  font-family: sans-serif;
+}
+
+.sidebar {
+  width: 220px;
+  background: #f5f5f5;
+  padding: 20px;
+}
+
+.logo {
+  margin-bottom: 20px;
+  font-weight: bold;
+}
+
+.navList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.navItem {
+  margin-bottom: 10px;
+}
+
+.navLink {
+  color: #333;
+  text-decoration: none;
+}
+
+.navLink:hover {
+  color: #0070f3;
+}
+
+.main {
+  flex: 1;
+  padding: 20px;
+}

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import styles from './AdminLayout.module.css';
+import React from 'react';
+
+const navItems = [
+  { href: '/admin/categories', label: 'Categories' },
+  { href: '/admin/trainings', label: 'Trainings' },
+  { href: '/admin/complexes', label: 'Complexes' },
+  { href: '/admin/exercises', label: 'Exercises' },
+  { href: '/admin/videos', label: 'Videos' },
+];
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+
+  const logout = () => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem('admin-token');
+    }
+    router.replace('/admin/login');
+  };
+
+  return (
+    <div className={styles.container}>
+      <aside className={styles.sidebar}>
+        <div className={styles.logo}>Admin</div>
+        <nav>
+          <ul className={styles.navList}>
+            {navItems.map(item => (
+              <li key={item.href} className={styles.navItem}>
+                <Link href={item.href} className={styles.navLink}>{item.label}</Link>
+              </li>
+            ))}
+            <li className={styles.navItem}>
+              <button onClick={logout}>Logout</button>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+      <main className={styles.main}>{children}</main>
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": "."
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- implement reusable AdminLayout with sidebar navigation and logout
- restructure admin pages with new dashboard and sections for categories, trainings, exercises, videos
- enable absolute imports via tsconfig baseUrl

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a5687f590832198e96fb1eb9c0d09