### PR TITLE
feat: integrate Tinkoff pay widget

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,6 +13,7 @@ export default function Home() {
         />
       </Head>
       <Script src="https://cdn.tailwindcss.com" strategy="beforeInteractive" />
+      <Script src="https://securepay.tinkoff.ru/html/payForm/js/tinkoff_v2.js" strategy="afterInteractive" />
       <App />
       <style jsx global>{`
         .no-scrollbar::-webkit-scrollbar { display: none; }

--- a/src/RehabMiniApp.tsx
+++ b/src/RehabMiniApp.tsx
@@ -10,6 +10,7 @@ import { Modal } from './components/Modal';
 import { DevTests } from './components/DevTests';
 import { sampleCategories } from './data/sampleCategories';
 import type { Category, Course, Exercise } from './types';
+import { TinkoffPayForm } from './components/TinkoffPayForm';
 
 export default function RehabMiniApp() {
   const envReady = useEnvReady();
@@ -25,6 +26,7 @@ export default function RehabMiniApp() {
   const [subActive, setSubActive] = useState<boolean>(false);
   const [cart, setCart] = useState<{ id: string; title: string; price: number; image: string; qty: number }[]>([]);
   const [tgUser, setTgUser] = useState<any | null>(null);
+  const [checkoutOpen, setCheckoutOpen] = useState(false);
 
   useEffect(() => {
     if (!envReady) return;
@@ -221,7 +223,7 @@ export default function RehabMiniApp() {
                 <div className="text-sm">
                   <b>{cart.reduce((s, i) => s + i.qty, 0)}</b> items • <b>${cart.reduce((s, i) => s + i.qty * i.price, 0).toFixed(2)}</b>
                 </div>
-                <button className="px-4 py-2 bg-white/10 text-white rounded-xl text-sm font-medium hover:bg-white/20 transition flex items-center gap-2" onClick={() => ping('Checkout complete (mock)')}>
+                <button className="px-4 py-2 bg-white/10 text-white rounded-xl text-sm font-medium hover:bg-white/20 transition flex items-center gap-2" onClick={() => setCheckoutOpen(true)}>
                   <i className="fa-solid fa-credit-card"></i>
                   <span>Checkout</span>
                 </button>
@@ -277,6 +279,13 @@ export default function RehabMiniApp() {
       {viewerCourse && (
         <VideoScreen course={viewerCourse} title={viewerCourse.title} onClose={() => setViewerCourse(null)} />
       )}
+
+      <Modal open={checkoutOpen} onClose={() => setCheckoutOpen(false)}>
+        <div className="p-4">
+          <h3 className="text-base font-semibold mb-1">Checkout</h3>
+          <TinkoffPayForm amount={cart.reduce((s, i) => s + i.qty * i.price, 0)} />
+        </div>
+      </Modal>
 
       <Modal open={paywallOpen} onClose={() => setPaywallOpen(false)}>
         <div className="p-4">

--- a/src/components/TinkoffPayForm.tsx
+++ b/src/components/TinkoffPayForm.tsx
@@ -1,0 +1,89 @@
+import { useRef } from 'react';
+
+export function TinkoffPayForm({ amount }: { amount: number }) {
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = formRef.current;
+    if (!form) return;
+    const description = (form.elements.namedItem('description') as HTMLInputElement);
+    const email = (form.elements.namedItem('email') as HTMLInputElement);
+    const phone = (form.elements.namedItem('phone') as HTMLInputElement);
+    const receipt = (form.elements.namedItem('receipt') as HTMLInputElement);
+
+    if (receipt) {
+      if (!email.value && !phone.value) {
+        alert('Поле E-mail или Phone не должно быть пустым');
+        return;
+      }
+      receipt.value = JSON.stringify({
+        EmailCompany: 'mail@mail.com',
+        Taxation: 'patent',
+        FfdVersion: '1.2',
+        Items: [
+          {
+            Name: description.value || 'Оплата',
+            Price: Math.round(amount * 100),
+            Quantity: 1.0,
+            Amount: Math.round(amount * 100),
+            PaymentMethod: 'full_prepayment',
+            PaymentObject: 'service',
+            Tax: 'none',
+            MeasurementUnit: 'pc',
+          },
+        ],
+      });
+    }
+    (window as any).pay(form);
+  };
+
+  return (
+    <form className="payform-tbank" ref={formRef} onSubmit={onSubmit}>
+      <input className="payform-tbank-row" type="hidden" name="terminalkey" value="TBankTest" />
+      <input className="payform-tbank-row" type="hidden" name="frame" value="false" />
+      <input className="payform-tbank-row" type="hidden" name="language" value="ru" />
+      <input className="payform-tbank-row" type="hidden" name="receipt" value="" />
+      <input className="payform-tbank-row" type="hidden" name="amount" value={amount} />
+      <input className="payform-tbank-row" type="hidden" name="order" />
+      <input className="payform-tbank-row" type="text" placeholder="Описание заказа" name="description" />
+      <input className="payform-tbank-row" type="text" placeholder="ФИО плательщика" name="name" />
+      <input className="payform-tbank-row" type="email" placeholder="E-mail" name="email" />
+      <input className="payform-tbank-row" type="tel" placeholder="Контактный телефон" name="phone" />
+      <input className="payform-tbank-row payform-tbank-btn" type="submit" value="Оплатить" />
+      <style jsx>{`
+        .payform-tbank {
+          display: flex;
+          margin: 2px auto;
+          flex-direction: column;
+          max-width: 250px;
+        }
+        .payform-tbank-row {
+          margin: 2px;
+          border-radius: 4px;
+          flex: 1;
+          transition: 0.3s;
+          border: 1px solid #DFE3F3;
+          padding: 15px;
+          outline: none;
+          background-color: #DFE3F3;
+          font-size: 15px;
+        }
+        .payform-tbank-row:focus {
+          background-color: #FFFFFF;
+          border: 1px solid #616871;
+          border-radius: 4px;
+        }
+        .payform-tbank-btn {
+          background-color: #FBC520;
+          border: 1px solid #FBC520;
+          color: #3C2C0B;
+        }
+        .payform-tbank-btn:hover {
+          background-color: #FAB619;
+          border: 1px solid #FAB619;
+        }
+      `}</style>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- load Tinkoff payment script
- add Tinkoff pay form component with receipt generation
- hook payment form into shop checkout modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b1ba245d883218992ca9161211abd