### PR TITLE
Hide shop tab temporarily

### DIFF
--- a/src/components/ActivePill.tsx
+++ b/src/components/ActivePill.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useRef } from 'react';
 
-export function ActivePill({ index }: { index: number }) {
+export function ActivePill({ index, count }: { index: number; count: number }) {
   const ref = useRef<HTMLDivElement | null>(null);
   useEffect(() => { if (ref.current) ref.current.style.transform = `translateX(${index * 100}%)`; }, [index]);
-  return <div ref={ref} className="absolute inset-y-1 left-1 w-1/3 rounded-xl bg-blue-900/30 transition-transform duration-300" aria-hidden />;
+  return (
+    <div
+      ref={ref}
+      className="absolute inset-y-1 left-1 rounded-xl bg-blue-900/30 transition-transform duration-300"
+      style={{ width: `${100 / count}%` }}
+      aria-hidden
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- remove shop tab and related logic from the mini app
- adjust navigation and active indicator to handle two tabs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b22577a2c8321865076f2ecb9c4f0