### PR TITLE
feat: move payment to separate screen

### DIFF
--- a/pages/pay.tsx
+++ b/pages/pay.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import Head from 'next/head';
+import Script from 'next/script';
+import Link from 'next/link';
+import { retrieveLaunchParams } from '@telegram-apps/sdk';
+import { TinkoffPayForm } from '../src/components/TinkoffPayForm';
+
+const SUB_PRICE = 799;
+const SUB_DESCRIPTION = 'Подписка Rehab';
+
+export default function Pay() {
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    try {
+      const lp = retrieveLaunchParams();
+      const u = lp?.initData?.user as any;
+      if (u) {
+        const fullName = [u.first_name, u.last_name].filter(Boolean).join(' ');
+        setName(fullName || u.username || '');
+      }
+    } catch {}
+  }, []);
+
+  const onPaid = () => {
+    try { window.localStorage.setItem('subActive', '1'); } catch {}
+    window.location.href = '/';
+  };
+
+  return (
+    <>
+      <Head>
+        <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+        />
+      </Head>
+      <Script src="https://cdn.tailwindcss.com" strategy="beforeInteractive" />
+      <Script src="https://securepay.tinkoff.ru/html/payForm/js/tinkoff_v2.js" strategy="afterInteractive" />
+      <div
+        className="w-full min-h-[100dvh] bg-neutral-950 text-gray-100 flex flex-col items-center justify-center px-4 text-center"
+        style={{ paddingTop: 'env(safe-area-inset-top)' }}
+      >
+        <h1 className="text-xl font-semibold mb-2">Оплата подписки</h1>
+        <p className="mb-1">Сумма платежа: {SUB_PRICE} ₽</p>
+        <p className="mb-4">Назначение: {SUB_DESCRIPTION}</p>
+        <p className="mb-6 text-sm text-gray-400 max-w-xs">
+          Оставьте ваш e-mail и телефон, мы пришлём чек и уведомление об оплате.
+        </p>
+        <TinkoffPayForm amount={SUB_PRICE} description={SUB_DESCRIPTION} name={name} onPaid={onPaid} />
+        <Link href="/" className="mt-4 text-sm text-blue-400">Назад</Link>
+      </div>
+      <style jsx global>{`
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+        .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+      `}</style>
+    </>
+  );
+}

--- a/src/components/TinkoffPayForm.tsx
+++ b/src/components/TinkoffPayForm.tsx
@@ -4,9 +4,10 @@ interface Props {
   amount: number;
   description?: string;
   onPaid?: () => void;
+  name?: string;
 }
 
-export function TinkoffPayForm({ amount, description, onPaid }: Props) {
+export function TinkoffPayForm({ amount, description, onPaid, name }: Props) {
   const formRef = useRef<HTMLFormElement | null>(null);
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -58,7 +59,11 @@ export function TinkoffPayForm({ amount, description, onPaid }: Props) {
       ) : (
         <input className="payform-tbank-row" type="text" placeholder="Описание заказа" name="description" />
       )}
-      <input className="payform-tbank-row" type="text" placeholder="ФИО плательщика" name="name" />
+      {name ? (
+        <input className="payform-tbank-row" type="hidden" name="name" value={name} />
+      ) : (
+        <input className="payform-tbank-row" type="text" placeholder="ФИО плательщика" name="name" />
+      )}
       <input className="payform-tbank-row" type="email" placeholder="E-mail" name="email" />
       <input className="payform-tbank-row" type="tel" placeholder="Контактный телефон" name="phone" />
       <input className="payform-tbank-row payform-tbank-btn" type="submit" value="Оплатить" />


### PR DESCRIPTION
## Summary
- route subscription actions to a dedicated payment page
- prefill Tinkoff form with user data so only email and phone are required
- add payment page to activate subscription and mark it active locally
- show payment amount, purpose and instructions on the pay screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b25c30a588321b0819faf96785f0d