### PR TITLE
feat: add Neon serverless and Drizzle setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables
+DATABASE_URL=""

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 .next/
+.env
+package-lock.json

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/schema.ts',
+  out: './drizzle',
+  driver: 'neon-http',
+  dbCredentials: {
+    connectionString: process.env.DATABASE_URL!,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -6,18 +6,23 @@
     "dev": "next dev",
     "build": "next build",
     "start": "node server.js",
-    "test": "echo \"No tests\""
+    "test": "echo \"No tests\"",
+    "db:generate": "drizzle-kit generate:pg",
+    "db:migrate": "drizzle-kit migrate"
   },
   "dependencies": {
     "next": "^14.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@telegram-apps/sdk": "^1.0.0"
+    "@telegram-apps/sdk": "^1.0.0",
+    "@neondatabase/serverless": "^0.9.0",
+    "drizzle-orm": "^0.29.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "drizzle-kit": "^0.20.0"
   }
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,5 @@
+import { neon } from '@neondatabase/serverless';
+import { drizzle } from 'drizzle-orm/neon-http';
+
+const sql = neon(process.env.DATABASE_URL!);
+export const db = drizzle(sql);

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,6 @@
+import { pgTable, serial, varchar } from 'drizzle-orm/pg-core';
+
+export const users = pgTable('users', {
+  id: serial('id').primaryKey(),
+  name: varchar('name', { length: 256 }),
+});


### PR DESCRIPTION
## Summary
- add Neon serverless driver and Drizzle ORM dependencies
- provide example Drizzle config and database schema
- ignore environment files and lock file

## Testing
- `npm test`
- `npm install @neondatabase/serverless drizzle-orm drizzle-kit` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b82b18424832198f2812079faaf8a