### PR TITLE
Register Telegram users and list in admin

### DIFF
--- a/pages/admin/users/index.tsx
+++ b/pages/admin/users/index.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import AdminLayout from 'src/components/admin/AdminLayout';
+import type { User } from 'src/types';
+
+const LIMIT = 10;
+
+export default function AdminUsers() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
+      router.replace('/admin/login');
+      return;
+    }
+    fetchUsers(page);
+  }, [page]);
+
+  const fetchUsers = async (p: number) => {
+    const res = await fetch(`/api/users?page=${p}&limit=${LIMIT}`);
+    const data = await res.json();
+    setUsers(data.users);
+    setTotal(data.total);
+  };
+
+  const totalPages = Math.ceil(total / LIMIT) || 1;
+
+  return (
+    <AdminLayout>
+      <h1>Users</h1>
+      <ul>
+        {users.map((u) => (
+          <li key={u.id}>
+            {u.name} ({u.userID})
+          </li>
+        ))}
+      </ul>
+      <div style={{ marginTop: 20 }}>
+        <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page <= 1}>
+          Prev
+        </button>
+        <span style={{ margin: '0 10px' }}>
+          Page {page} / {totalPages}
+        </span>
+        <button onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page >= totalPages}>
+          Next
+        </button>
+      </div>
+    </AdminLayout>
+  );
+}
+

--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -1,15 +1,39 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { eq, sql } from 'drizzle-orm';
 import { db, users } from '../../../src/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   switch (req.method) {
     case 'GET': {
-      const allUsers = await db.select().from(users);
-      res.status(200).json(allUsers);
+      const { page = '1', limit = '10' } = req.query;
+      const p = parseInt(Array.isArray(page) ? page[0] : page as string, 10) || 1;
+      const l = parseInt(Array.isArray(limit) ? limit[0] : limit as string, 10) || 10;
+      const offset = (p - 1) * l;
+
+      const pageUsers = await db.select().from(users).limit(l).offset(offset);
+      const totalResult = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(users);
+      const total = Number(totalResult[0]?.count || 0);
+
+      res.status(200).json({ users: pageUsers, total });
       break;
     }
     case 'POST': {
       const userData = req.body;
+      if (!userData?.userID) {
+        res.status(400).json({ error: 'userID required' });
+        break;
+      }
+      const existing = await db
+        .select()
+        .from(users)
+        .where(eq(users.userID, userData.userID))
+        .limit(1);
+      if (existing.length) {
+        res.status(200).json(existing[0]);
+        break;
+      }
       const inserted = await db.insert(users).values(userData).returning();
       res.status(201).json(inserted[0]);
       break;

--- a/src/RehabMiniApp.tsx
+++ b/src/RehabMiniApp.tsx
@@ -42,6 +42,21 @@ export default function RehabMiniApp() {
   }, []);
 
   useEffect(() => {
+    if (!tgUser) return;
+    const body = {
+      userID: String(tgUser.id),
+      name: [tgUser.first_name, tgUser.last_name].filter(Boolean).join(' '),
+      username: tgUser.username,
+      email: '',
+    };
+    fetch('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).catch(() => {});
+  }, [tgUser]);
+
+  useEffect(() => {
     if (!envReady) return;
     try {
       const wa = (window as any).Telegram?.WebApp;

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -9,6 +9,7 @@ const navItems = [
   { href: '/admin/complexes', label: 'Complexes' },
   { href: '/admin/exercises', label: 'Exercises' },
   { href: '/admin/videos', label: 'Videos' },
+  { href: '/admin/users', label: 'Users' },
 ];
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,3 +30,15 @@ export type Lap = {
 export type Course = { id: string; title: string; laps: Lap[] };
 
 export type Category = { id: string; title: string; courses: Course[] };
+
+export type User = {
+  id: number;
+  userID: string;
+  name: string;
+  username?: string | null;
+  email: string;
+  contactNumber?: string | null;
+  subscriptionPlan?: string | null;
+  isSubscribed: boolean;
+  subscriptionExpiresAt?: string | null;
+};


### PR DESCRIPTION
## Summary
- store Telegram user information on first launch
- add user listing with pagination to admin panel
- support paginated API endpoints for users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c46e837688321935910717c08cf6c