### PR TITLE
Add database connection logging

### DIFF
--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -4,6 +4,7 @@ import { db, users } from '../../../src/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   console.log(`[${new Date().toISOString()}] ${req.method} /api/users`);
+  console.log(`Database instance: ${db ? 'initialized' : 'not initialized'}`);
   try {
     switch (req.method) {
       case 'GET': {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -8,11 +8,23 @@ let db: NeonHttpDatabase<typeof schema>;
 try {
   console.log("Initializing database connection");
   if (!process.env.DATABASE_URL) {
+    console.error("DATABASE_URL is not defined");
     throw new Error("DATABASE_URL is not defined");
   }
+  console.log("DATABASE_URL is present");
+
   const sql = neon(process.env.DATABASE_URL);
   db = drizzle(sql, { schema });
   console.log("Database connection established");
+
+  (async () => {
+    try {
+      await sql`select 1`;
+      console.log("Database connection test query succeeded");
+    } catch (err) {
+      console.error("Database connection test query failed", err);
+    }
+  })();
 } catch (error) {
   console.error("Failed to initialize database connection", error);
   throw error;


### PR DESCRIPTION
## Summary
- log presence of database URL and test DB connection on startup
- report database instance status for `/api/users` requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c5b8e51bc832198d8cfc37a4939bd