### PR TITLE
feat: embed admin panel in admin tab

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -1,8 +1,8 @@
 export function AdminPanel() {
   return (
-    <div className="px-4 pt-4">
-      <h2 className="text-lg font-bold mb-2">Admin Panel</h2>
-      <p className="text-sm text-gray-400">Admin features go here.</p>
-    </div>
+    <iframe
+      src="/admin"
+      className="w-full h-[calc(100dvh-5rem)] border-0 bg-white"
+    />
   );
 }


### PR DESCRIPTION
## Summary
- load the existing admin dashboard inside the app's Admin tab via iframe

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c5dceb7f88321955fb80e5631dd58