### PR TITLE
chore: guard TelegramGameProxy

### DIFF
--- a/pages/pay.tsx
+++ b/pages/pay.tsx
@@ -13,6 +13,9 @@ export default function Pay() {
 
   useEffect(() => {
     try {
+      if (!(window as any).TelegramGameProxy) {
+        (window as any).TelegramGameProxy = { receiveEvent: () => {} };
+      }
       const lp = retrieveLaunchParams();
       const u = lp?.initData?.user as any;
       if (u) {

--- a/src/RehabMiniApp.tsx
+++ b/src/RehabMiniApp.tsx
@@ -39,6 +39,9 @@ export default function RehabMiniApp() {
 
   useEffect(() => {
     try {
+      if (!(window as any).TelegramGameProxy) {
+        (window as any).TelegramGameProxy = { receiveEvent: () => {} };
+      }
       const lp = retrieveLaunchParams();
       // lp.initData?.user contains Telegram user info if available
       const u = lp?.initData?.user as any;


### PR DESCRIPTION
## Summary
- guard TelegramGameProxy when retrieving launch params to avoid runtime errors outside Telegram

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c5f5007ec832186e846d039675c52