### PR TITLE
feat(api): handle options requests

### DIFF
--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -2,9 +2,21 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { eq, sql } from 'drizzle-orm';
 import { db, users } from '../../../src/db';
 
+function setCors(res: NextApiResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   console.log(`[${new Date().toISOString()}] ${req.method} /api/users`);
   console.log(`Database instance: ${db ? 'initialized' : 'not initialized'}`);
+  setCors(res);
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
   try {
     switch (req.method) {
       case 'GET': {
@@ -54,7 +66,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         break;
       }
       default:
-        res.setHeader('Allow', ['GET', 'POST']);
+        res.setHeader('Allow', ['GET', 'POST', 'OPTIONS']);
         res.status(405).end(`Method ${req.method} Not Allowed`);
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- add CORS headers for `/api/users`
- support preflight OPTIONS requests

## Testing
- `npm test`
- `curl -i -X OPTIONS http://localhost:3000/api/users`
- `curl -i -X POST http://localhost:3000/api/users -H "Content-Type: application/json" -d '{"userID":"1"}'`

------
https://chatgpt.com/codex/tasks/task_e_689c7a0c85d88321ae87a2ebe2b24753