### PR TITLE
Use defineConfig for drizzle and set DATABASE_URL for Vercel builds

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,10 @@
-import type { Config } from "drizzle-kit";
+import { defineConfig } from "drizzle-kit";
 
-export default {
+export default defineConfig({
   schema: "./src/db/schema.ts",
   out: "./drizzle",
-  driver: "pg",
   dialect: "postgresql",
   dbCredentials: {
-    connectionString: process.env.DATABASE_URL!,
+    url: process.env.DATABASE_URL!,
   },
-} satisfies Config;
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,5 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
-  "framework": "nextjs",
-  "env": {
-    "DATABASE_URL": "@database-url"
-  }
+  "framework": "nextjs"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "env": {
+    "DATABASE_URL": "@database-url"
+  }
 }


### PR DESCRIPTION
## Summary
- switch drizzle config to `defineConfig` with `dbCredentials.url`
- expose `DATABASE_URL` in Vercel config for build-time `drizzle-kit` commands

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c855bbdf88321a9e944d9f1811c55