### PR TITLE
feat: streamline admin navigation

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,10 +1,30 @@
+import Link from 'next/link';
 import AdminLayout from 'src/components/admin/AdminLayout';
 
 export default function AdminDashboard() {
   return (
     <AdminLayout>
-      <h1 className="text-2xl font-bold mb-2">Dashboard</h1>
-      <p className="text-gray-300">Select a section from the menu to manage content.</p>
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <div className="space-y-4 max-w-xs">
+        <Link
+          href="/admin/subscription"
+          className="block px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
+        >
+          Subscription Settings
+        </Link>
+        <Link
+          href="/admin/categories"
+          className="block px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
+        >
+          Categories Settings
+        </Link>
+        <Link
+          href="/admin/users"
+          className="block px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
+        >
+          Users Settings
+        </Link>
+      </div>
     </AdminLayout>
   );
 }

--- a/pages/admin/subscription/index.tsx
+++ b/pages/admin/subscription/index.tsx
@@ -1,0 +1,10 @@
+import AdminLayout from 'src/components/admin/AdminLayout';
+
+export default function SubscriptionSettings() {
+  return (
+    <AdminLayout>
+      <h1 className="text-2xl font-bold mb-2">Subscription Settings</h1>
+      <p className="text-gray-300">Manage subscription plans here.</p>
+    </AdminLayout>
+  );
+}

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -2,15 +2,12 @@ import { useEffect, useState } from 'react';
 import type { User, Category } from '../types';
 
 const USERS_LIMIT = 10;
-const navItems = [
-  { id: 'dashboard', label: 'Dashboard' },
-  { id: 'users', label: 'Users' },
-  { id: 'categories', label: 'Categories' },
-];
+
+type Section = 'dashboard' | 'subscriptions' | 'users' | 'categories';
 
 export function AdminPanel() {
   const [authed, setAuthed] = useState(false);
-  const [section, setSection] = useState<'dashboard' | 'users' | 'categories'>('dashboard');
+  const [section, setSection] = useState<Section>('dashboard');
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -33,10 +30,15 @@ export function AdminPanel() {
   let content: JSX.Element | null = null;
   if (section === 'users') content = <UsersSection />;
   else if (section === 'categories') content = <CategoriesSection />;
-  else content = <DashboardSection />;
+  else if (section === 'subscriptions') content = <SubscriptionsSection />;
+  else content = <DashboardSection onNavigate={setSection} />;
 
   return (
-    <AdminShell section={section} onNavigate={setSection} onLogout={handleLogout}>
+    <AdminShell
+      section={section}
+      onBack={() => setSection('dashboard')}
+      onLogout={handleLogout}
+    >
       {content}
     </AdminShell>
   );
@@ -79,78 +81,78 @@ function AdminLogin({ onSuccess }: { onSuccess: () => void }) {
 
 function AdminShell({
   section,
-  onNavigate,
+  onBack,
   onLogout,
   children,
 }: {
-  section: 'dashboard' | 'users' | 'categories';
-  onNavigate: (s: 'dashboard' | 'users' | 'categories') => void;
+  section: Section;
+  onBack: () => void;
   onLogout: () => void;
   children: React.ReactNode;
 }) {
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined' && window.innerWidth >= 768) {
-      setSidebarOpen(true);
-    }
-  }, []);
-
-  const toggleSidebar = () => setSidebarOpen((prev) => !prev);
-  const closeSidebar = () => setSidebarOpen(false);
-
   return (
-    <div className="flex min-h-[calc(100dvh-5rem)] bg-neutral-950 text-gray-100">
-      <aside
-        className={`fixed inset-y-0 left-0 z-20 w-64 bg-neutral-900 border-r border-neutral-800 transform transition-transform md:translate-x-0 ${
-          sidebarOpen ? 'translate-x-0' : '-translate-x-full'
-        }`}
-      >
-        <div className="p-4 text-xl font-bold">Admin</div>
-        <nav className="px-2 space-y-1">
-          {navItems.map((item) => (
+    <div className="min-h-[calc(100dvh-5rem)] bg-neutral-950 text-gray-100">
+      <header className="h-14 flex items-center justify-between px-4 border-b border-neutral-800 bg-neutral-950">
+        <div className="flex items-center gap-2">
+          {section !== 'dashboard' && (
             <button
-              key={item.id}
-              className={`block w-full text-left px-4 py-2 rounded-lg transition-colors ${
-                section === item.id ? 'bg-neutral-800 text-white' : 'text-gray-300 hover:bg-neutral-800'
-              }`}
-              onClick={() => {
-                onNavigate(item.id as any);
-                closeSidebar();
-              }}
+              className="text-sm text-gray-300 hover:text-white"
+              onClick={onBack}
             >
-              {item.label}
+              Back
             </button>
-          ))}
-          <button
-            className="w-full text-left px-4 py-2 rounded-lg text-gray-300 hover:bg-neutral-800"
-            onClick={onLogout}
-          >
-            Logout
-          </button>
-        </nav>
-      </aside>
-
-      {sidebarOpen && <div className="fixed inset-0 z-10 bg-black/50 md:hidden" onClick={closeSidebar} />}
-
-      <div className="flex-1 md:ml-64">
-        <header className="h-14 flex items-center px-4 border-b border-neutral-800 bg-neutral-950">
-          <button className="md:hidden mr-2" onClick={toggleSidebar}>
-            <i className="fa-solid fa-bars" />
-          </button>
+          )}
           <span className="font-semibold">Admin Panel</span>
-        </header>
-        <main className="p-4">{children}</main>
-      </div>
+        </div>
+        <button
+          className="text-sm text-gray-300 hover:text-white"
+          onClick={onLogout}
+        >
+          Logout
+        </button>
+      </header>
+      <main className="p-4">{children}</main>
     </div>
   );
 }
 
-function DashboardSection() {
+function DashboardSection({
+  onNavigate,
+}: {
+  onNavigate: (s: 'subscriptions' | 'categories' | 'users') => void;
+}) {
   return (
     <>
-      <h1 className="text-2xl font-bold mb-2">Dashboard</h1>
-      <p className="text-gray-300">Select a section from the menu to manage content.</p>
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <div className="space-y-4 max-w-xs">
+        <button
+          className="w-full px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
+          onClick={() => onNavigate('subscriptions')}
+        >
+          Subscription Settings
+        </button>
+        <button
+          className="w-full px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
+          onClick={() => onNavigate('categories')}
+        >
+          Categories Settings
+        </button>
+        <button
+          className="w-full px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
+          onClick={() => onNavigate('users')}
+        >
+          Users Settings
+        </button>
+      </div>
+    </>
+  );
+}
+
+function SubscriptionsSection() {
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-2">Subscription Settings</h1>
+      <p className="text-gray-300">Manage subscription plans here.</p>
     </>
   );
 }

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -1,26 +1,10 @@
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Script from 'next/script';
-import React, { useEffect, useState } from 'react';
-
-const navItems = [
-  { href: '/admin/users', label: 'Users' },
-  { href: '/admin/categories', label: 'Categories' },
-];
+import React from 'react';
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined' && window.innerWidth >= 768) {
-      setSidebarOpen(true);
-    }
-  }, []);
-
-  const toggleSidebar = () => setSidebarOpen((prev) => !prev);
-  const closeSidebar = () => setSidebarOpen(false);
 
   const logout = () => {
     if (typeof window !== 'undefined') {
@@ -38,53 +22,17 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
         />
       </Head>
       <Script src="https://cdn.tailwindcss.com" strategy="beforeInteractive" />
-      <div className="flex min-h-screen bg-neutral-950 text-gray-100">
-        <aside
-          className={`fixed inset-y-0 left-0 z-20 w-64 bg-neutral-900 border-r border-neutral-800 transform transition-transform md:translate-x-0 ${
-            sidebarOpen ? 'translate-x-0' : '-translate-x-full'
-          }`}
-        >
-          <div className="p-4 text-xl font-bold">Admin</div>
-          <nav className="px-2 space-y-1">
-            {navItems.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={`block px-4 py-2 rounded-lg transition-colors ${
-                  router.pathname.startsWith(item.href)
-                    ? 'bg-neutral-800 text-white'
-                    : 'text-gray-300 hover:bg-neutral-800'
-                }`}
-                onClick={closeSidebar}
-              >
-                {item.label}
-              </Link>
-            ))}
-            <button
-              className="w-full text-left px-4 py-2 rounded-lg text-gray-300 hover:bg-neutral-800"
-              onClick={logout}
-            >
-              Logout
-            </button>
-          </nav>
-        </aside>
-
-        {sidebarOpen && (
-          <div
-            className="fixed inset-0 z-10 bg-black/50 md:hidden"
-            onClick={closeSidebar}
-          />
-        )}
-
-        <div className="flex-1 md:ml-64">
-          <header className="h-14 flex items-center px-4 border-b border-neutral-800 bg-neutral-950">
-            <button className="md:hidden mr-2" onClick={toggleSidebar}>
-              <i className="fa-solid fa-bars" />
-            </button>
-            <span className="font-semibold">Admin Panel</span>
-          </header>
-          <main className="p-4">{children}</main>
-        </div>
+      <div className="min-h-screen bg-neutral-950 text-gray-100">
+        <header className="h-14 flex items-center justify-between px-4 border-b border-neutral-800 bg-neutral-950">
+          <span className="font-semibold">Admin Panel</span>
+          <button
+            className="text-sm text-gray-300 hover:text-white"
+            onClick={logout}
+          >
+            Logout
+          </button>
+        </header>
+        <main className="p-4">{children}</main>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- remove sidebar from admin layout and use header with logout
- add dashboard buttons for subscription, categories and users
- stub subscription settings page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc6b15b988321b289884d17db4e70