### PR TITLE
Make category and training items navigable

### DIFF
--- a/pages/admin/categories/[id].tsx
+++ b/pages/admin/categories/[id].tsx
@@ -75,15 +75,32 @@ export default function CategoryDetail() {
     <AdminLayout>
       <button onClick={() => router.push('/admin/categories')}>Back</button>
       <h1>Category: {category?.title}</h1>
-      <ul>
+      <ul className="space-y-2 mb-8">
         {courses.map((c) => (
-          <li key={c.id}>
-            {c.title} ({c.id}){' '}
-            <button onClick={() => handleEdit(c)}>Edit</button>
-            <button onClick={() => handleDelete(c.id)}>Delete</button>
-            <Link href={`/admin/courses/${c.id}`} style={{ marginLeft: 10 }}>
-              Exercises
+          <li
+            key={c.id}
+            className="flex items-center justify-between bg-neutral-900 px-4 py-2 rounded-lg"
+          >
+            <Link
+              href={`/admin/courses/${c.id}`}
+              className="font-medium hover:underline"
+            >
+              {c.title}
             </Link>
+            <div className="flex items-center gap-3 text-sm">
+              <button
+                className="text-blue-400 hover:underline"
+                onClick={() => handleEdit(c)}
+              >
+                Edit
+              </button>
+              <button
+                className="text-red-400 hover:underline"
+                onClick={() => handleDelete(c.id)}
+              >
+                Delete
+              </button>
+            </div>
           </li>
         ))}
       </ul>

--- a/pages/admin/categories/index.tsx
+++ b/pages/admin/categories/index.tsx
@@ -66,7 +66,12 @@ export default function AdminCategories() {
             key={cat.id}
             className="flex items-center justify-between bg-neutral-900 px-4 py-2 rounded-lg"
           >
-            <span className="font-medium">{cat.title}</span>
+            <Link
+              href={`/admin/categories/${cat.id}`}
+              className="font-medium hover:underline"
+            >
+              {cat.title}
+            </Link>
             <div className="flex items-center gap-3 text-sm">
               <button
                 className="text-blue-400 hover:underline"
@@ -80,12 +85,6 @@ export default function AdminCategories() {
               >
                 Delete
               </button>
-              <Link
-                href={`/admin/categories/${cat.id}`}
-                className="text-gray-400 hover:underline"
-              >
-                Trainings
-              </Link>
             </div>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- Allow tapping a category name to open its training list
- Make training titles link to their exercise management screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ccad9b9588321a1a5881eff3acfb2