### PR TITLE
refactor: use training name in admin list

### DIFF
--- a/pages/admin/trainings/index.tsx
+++ b/pages/admin/trainings/index.tsx
@@ -28,7 +28,7 @@ export default function AdminTrainings() {
       <ul>
         {trainings.map((t) => (
           <li key={t.id}>
-            {t.title}
+            {t.name}
             <Link href={`/admin/trainings/${t.id}`} style={{ marginLeft: 10 }}>
               Edit
             </Link>


### PR DESCRIPTION
## Summary
- replace admin trainings list item to show training.name

## Testing
- `npm test`
- `npm run build` *(fails: Object literal may only specify known properties, and 'title' does not exist in type 'Training')*

------
https://chatgpt.com/codex/tasks/task_e_689d913bc81c8321b84fa0dba7c79550