### PR TITLE
Refactor category admin to new schema

### DIFF
--- a/pages/admin/categories/[id].tsx
+++ b/pages/admin/categories/[id].tsx
@@ -1,10 +1,22 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import Link from 'next/link';
-import type { Category, Training } from 'src/types';
 import AdminLayout from 'src/components/admin/AdminLayout';
 
-const emptyTraining = { id: '', title: '' };
+type Training = {
+  id: string;
+  name: string;
+  description: string;
+  coverUrl: string;
+};
+
+type Category = {
+  id: string;
+  name: string;
+  coverUrl: string;
+  trainings: Training[];
+};
+
+const emptyTraining = { name: '', description: '', coverUrl: '' };
 
 export default function CategoryDetail() {
   const router = useRouter();
@@ -35,22 +47,22 @@ export default function CategoryDetail() {
     e.preventDefault();
     if (!category) return;
     if (editId && editingTraining) {
-      const updated: Training = { ...editingTraining, title: form.title };
+      const updated: Training = {
+        ...editingTraining,
+        name: form.name,
+        description: form.description,
+        coverUrl: form.coverUrl,
+      };
       await fetch(`/api/trainings/${editId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(updated),
       });
     } else {
-      const newTraining: Training = {
-        id: form.id,
-        title: form.title,
-        complexes: [{ id: 'main', title: 'Main', exercises: [] }],
-      };
       await fetch('/api/trainings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ categoryId: category.id, training: newTraining }),
+        body: JSON.stringify({ categoryId: category.id, training: form }),
       });
     }
     setForm(emptyTraining);
@@ -62,7 +74,7 @@ export default function CategoryDetail() {
   const handleEdit = (training: Training) => {
     setEditId(training.id);
     setEditingTraining(training);
-    setForm({ id: training.id, title: training.title });
+    setForm({ name: training.name, description: training.description, coverUrl: training.coverUrl });
   };
 
   const handleDelete = async (trainingId: string) => {
@@ -74,31 +86,32 @@ export default function CategoryDetail() {
   return (
     <AdminLayout>
       <button onClick={() => router.push('/admin/categories')}>Back</button>
-      <h1>Category: {category?.title}</h1>
+      <h1>Category: {category?.name}</h1>
       <ul>
         {trainings.map((t) => (
           <li key={t.id}>
-            {t.title} ({t.id}){' '}
+            {t.name} ({t.id}){' '}
             <button onClick={() => handleEdit(t)}>Edit</button>
             <button onClick={() => handleDelete(t.id)}>Delete</button>
-            <Link href={`/admin/trainings/${t.id}`} style={{ marginLeft: 10 }}>
-              Exercises
-            </Link>
           </li>
         ))}
       </ul>
       <h2 style={{ marginTop: 30 }}>{editId ? 'Edit' : 'Add'} Training</h2>
       <form onSubmit={handleSubmit}>
         <input
-          value={form.id}
-          onChange={(e) => setForm({ ...form, id: e.target.value })}
-          placeholder="id"
-          disabled={!!editId}
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          placeholder="name"
+        />
+        <textarea
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+          placeholder="description"
         />
         <input
-          value={form.title}
-          onChange={(e) => setForm({ ...form, title: e.target.value })}
-          placeholder="title"
+          value={form.coverUrl}
+          onChange={(e) => setForm({ ...form, coverUrl: e.target.value })}
+          placeholder="coverUrl"
         />
         <button type="submit">{editId ? 'Update' : 'Create'}</button>
       </form>

--- a/pages/admin/categories/index.tsx
+++ b/pages/admin/categories/index.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import type { Category } from 'src/types';
 import AdminLayout from 'src/components/admin/AdminLayout';
 
-const emptyForm = { id: '', title: '' };
+type Category = {
+  id: string;
+  name: string;
+  coverUrl: string;
+};
+
+const emptyForm = { name: '', coverUrl: '' };
 
 export default function AdminCategories() {
   const [categories, setCategories] = useState<Category[]>([]);
@@ -48,7 +53,7 @@ export default function AdminCategories() {
 
   const handleEdit = (cat: Category) => {
     setEditId(cat.id);
-    setForm({ id: cat.id, title: cat.title });
+    setForm({ name: cat.name, coverUrl: cat.coverUrl });
   };
 
   const handleDelete = async (id: string) => {
@@ -66,7 +71,16 @@ export default function AdminCategories() {
             key={cat.id}
             className="flex items-center justify-between bg-neutral-900 px-4 py-2 rounded-lg"
           >
-            <span className="font-medium">{cat.title}</span>
+            <div className="flex items-center gap-3">
+              {cat.coverUrl && (
+                <img
+                  src={cat.coverUrl}
+                  alt={cat.name}
+                  className="w-10 h-10 object-cover rounded"
+                />
+              )}
+              <span className="font-medium">{cat.name}</span>
+            </div>
             <div className="flex items-center gap-3 text-sm">
               <button
                 className="text-blue-400 hover:underline"
@@ -95,16 +109,15 @@ export default function AdminCategories() {
       </h2>
       <form onSubmit={handleSubmit} className="space-y-3 max-w-sm">
         <input
-          value={form.id}
-          onChange={(e) => setForm({ ...form, id: e.target.value })}
-          placeholder="id"
-          disabled={!!editId}
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          placeholder="name"
           className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
         />
         <input
-          value={form.title}
-          onChange={(e) => setForm({ ...form, title: e.target.value })}
-          placeholder="title"
+          value={form.coverUrl}
+          onChange={(e) => setForm({ ...form, coverUrl: e.target.value })}
+          placeholder="coverUrl"
           className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
         />
         <button


### PR DESCRIPTION
## Summary
- Replace category title/id fields with name/coverUrl and auto-generated IDs
- Add cover preview and simplified CRUD form for categories
- Manage trainings within categories using name, description and coverUrl only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689da14dad74832191433ef7097a1c04