### PR TITLE
refactor: extract trainings section

### DIFF
--- a/pages/admin/trainings/index.tsx
+++ b/pages/admin/trainings/index.tsx
@@ -1,40 +1,21 @@
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import { useEffect } from 'react';
 import { useRouter } from 'next/router';
-import type { Training } from 'src/types';
 import AdminLayout from 'src/components/admin/AdminLayout';
+import { TrainingsSection } from 'src/components/admin/TrainingsSection';
 
-export default function AdminTrainings() {
-  const [trainings, setTrainings] = useState<Training[]>([]);
+export default function AdminTrainingsPage() {
   const router = useRouter();
 
   useEffect(() => {
     if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
       router.replace('/admin/login');
-      return;
     }
-    fetchTrainings();
-  }, []);
-
-  const fetchTrainings = async () => {
-    const res = await fetch('/api/trainings');
-    const data = await res.json();
-    setTrainings(data);
-  };
+  }, [router]);
 
   return (
     <AdminLayout>
-      <h1>Trainings</h1>
-      <ul>
-        {trainings.map((t) => (
-          <li key={t.id}>
-            {t.title}
-            <Link href={`/admin/trainings/${t.id}`} style={{ marginLeft: 10 }}>
-              Edit
-            </Link>
-          </li>
-        ))}
-      </ul>
+      <TrainingsSection />
     </AdminLayout>
   );
 }
+

--- a/src/components/admin/TrainingsSection.tsx
+++ b/src/components/admin/TrainingsSection.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { Training } from 'src/types';
+
+export function TrainingsSection() {
+  const [trainings, setTrainings] = useState<Training[]>([]);
+
+  useEffect(() => {
+    fetchTrainings();
+  }, []);
+
+  const fetchTrainings = async () => {
+    const res = await fetch('/api/trainings');
+    const data = await res.json();
+    setTrainings(data);
+  };
+
+  return (
+    <>
+      <h1>Trainings</h1>
+      <ul>
+        {trainings.map((t) => (
+          <li key={t.id}>
+            {t.title}
+            <Link href={`/admin/trainings/${t.id}`} style={{ marginLeft: 10 }}>
+              Edit
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- move trainings list logic into reusable `TrainingsSection`
- slim down trainings admin page to auth check and section component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e1394b8388321837923e12fadc270