### PR TITLE
refactor: extract admin exercises section

### DIFF
--- a/pages/admin/exercises/index.tsx
+++ b/pages/admin/exercises/index.tsx
@@ -1,40 +1,10 @@
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
-import type { Exercise } from 'src/types';
 import AdminLayout from 'src/components/admin/AdminLayout';
-
-interface DBExercise extends Exercise {
-  complexId: string;
-}
+import { ExercisesSection } from 'src/components/admin/ExercisesSection';
 
 export default function AdminExercises() {
-  const [exercises, setExercises] = useState<DBExercise[]>([]);
-  const router = useRouter();
-
-  useEffect(() => {
-    if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
-      router.replace('/admin/login');
-      return;
-    }
-    fetchExercises();
-  }, []);
-
-  const fetchExercises = async () => {
-    const res = await fetch('/api/exercises');
-    const data = await res.json();
-    setExercises(data);
-  };
-
   return (
     <AdminLayout>
-      <h1>Exercises</h1>
-      <ul>
-        {exercises.map((ex) => (
-          <li key={ex.id}>
-            {ex.title} – {ex.complexId}
-          </li>
-        ))}
-      </ul>
+      <ExercisesSection />
     </AdminLayout>
   );
 }

--- a/src/components/admin/ExercisesSection.tsx
+++ b/src/components/admin/ExercisesSection.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import type { Exercise } from '../../types';
+
+interface DBExercise extends Exercise {
+  complexId: string;
+}
+
+export function ExercisesSection() {
+  const [exercises, setExercises] = useState<DBExercise[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
+      router.replace('/admin/login');
+      return;
+    }
+    fetchExercises();
+  }, []);
+
+  const fetchExercises = async () => {
+    const res = await fetch('/api/exercises');
+    const data = await res.json();
+    setExercises(data);
+  };
+
+  return (
+    <>
+      <h1>Exercises</h1>
+      <ul>
+        {exercises.map((ex) => (
+          <li key={ex.id}>
+            {ex.title} – {ex.complexId}
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- move exercises fetching and list rendering to `ExercisesSection`
- use `ExercisesSection` in admin exercises page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e143246b883218b4e4bf743cc6eed