### PR TITLE
refactor: extract admin sections

### DIFF
--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,30 +1,10 @@
-import Link from 'next/link';
 import AdminLayout from 'src/components/admin/AdminLayout';
+import { DashboardSection } from 'src/components/admin/DashboardSection';
 
 export default function AdminDashboard() {
   return (
     <AdminLayout>
-      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
-      <div className="space-y-4 max-w-xs">
-        <Link
-          href="/admin/subscription"
-          className="block px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
-        >
-          Subscription Settings
-        </Link>
-        <Link
-          href="/admin/categories"
-          className="block px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
-        >
-          Categories Settings
-        </Link>
-        <Link
-          href="/admin/users"
-          className="block px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
-        >
-          Users Settings
-        </Link>
-      </div>
+      <DashboardSection />
     </AdminLayout>
   );
 }

--- a/pages/admin/subscription/index.tsx
+++ b/pages/admin/subscription/index.tsx
@@ -1,10 +1,10 @@
 import AdminLayout from 'src/components/admin/AdminLayout';
+import { SubscriptionsSection } from 'src/components/admin/SubscriptionsSection';
 
 export default function SubscriptionSettings() {
   return (
     <AdminLayout>
-      <h1 className="text-2xl font-bold mb-2">Subscription Settings</h1>
-      <p className="text-gray-300">Manage subscription plans here.</p>
+      <SubscriptionsSection />
     </AdminLayout>
   );
 }

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import type { User } from '../types';
 import { CategoriesSection } from './admin/CategoriesSection';
+import { SubscriptionsSection } from './admin/SubscriptionsSection';
+import { DashboardSection } from './admin/DashboardSection';
 
 const USERS_LIMIT = 10;
 
@@ -114,47 +116,6 @@ function AdminShell({
       </header>
       <main className="p-4">{children}</main>
     </div>
-  );
-}
-
-function DashboardSection({
-  onNavigate,
-}: {
-  onNavigate: (s: 'subscriptions' | 'categories' | 'users') => void;
-}) {
-  return (
-    <>
-      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
-      <div className="space-y-4 max-w-xs">
-        <button
-          className="w-full px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
-          onClick={() => onNavigate('subscriptions')}
-        >
-          Subscription Settings
-        </button>
-        <button
-          className="w-full px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
-          onClick={() => onNavigate('categories')}
-        >
-          Categories Settings
-        </button>
-        <button
-          className="w-full px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
-          onClick={() => onNavigate('users')}
-        >
-          Users Settings
-        </button>
-      </div>
-    </>
-  );
-}
-
-function SubscriptionsSection() {
-  return (
-    <>
-      <h1 className="text-2xl font-bold mb-2">Subscription Settings</h1>
-      <p className="text-gray-300">Manage subscription plans here.</p>
-    </>
   );
 }
 

--- a/src/components/admin/DashboardSection.tsx
+++ b/src/components/admin/DashboardSection.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+
+type Section = 'subscriptions' | 'categories' | 'users';
+
+export function DashboardSection({ onNavigate }: { onNavigate?: (s: Section) => void }) {
+  const items: { key: Section; label: string; href: string }[] = [
+    { key: 'subscriptions', label: 'Subscription Settings', href: '/admin/subscription' },
+    { key: 'categories', label: 'Categories Settings', href: '/admin/categories' },
+    { key: 'users', label: 'Users Settings', href: '/admin/users' },
+  ];
+
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <div className="space-y-4 max-w-xs">
+        {items.map((item) =>
+          onNavigate ? (
+            <button
+              key={item.key}
+              className="w-full px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
+              onClick={() => onNavigate(item.key)}
+            >
+              {item.label}
+            </button>
+          ) : (
+            <Link
+              key={item.key}
+              href={item.href}
+              className="block px-4 py-2 rounded-lg bg-neutral-800 text-center hover:bg-neutral-700"
+            >
+              {item.label}
+            </Link>
+          )
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/admin/SubscriptionsSection.tsx
+++ b/src/components/admin/SubscriptionsSection.tsx
@@ -1,0 +1,8 @@
+export function SubscriptionsSection() {
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-2">Subscription Settings</h1>
+      <p className="text-gray-300">Manage subscription plans here.</p>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- factor out admin Dashboard and Subscriptions sections into dedicated components
- reuse new sections in AdminPanel and admin pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e145a08348321b901d2dc6f0b0d6a