### PR TITLE
Refine tab bar active indicator and spacing

### DIFF
--- a/src/RehabMiniApp.tsx
+++ b/src/RehabMiniApp.tsx
@@ -268,7 +268,7 @@ export default function RehabMiniApp() {
       <nav className="fixed bottom-3 left-0 right-0">
         <div className="max-w-lg mx-auto">
           <div className="mx-4 bg-black/70 backdrop-blur border border-neutral-800 shadow-lg rounded-2xl">
-            <div className="grid grid-cols-4 h-16 text-xs relative">
+            <div className="grid grid-cols-4 h-16 text-xs relative gap-1 p-1">
               <ActivePill index={['home','profile','debug','admin'].indexOf(tab)} count={4} />
               <TabButton label="Home" active={tab==='home'} onClick={()=>setTab('home')} icon={<i className="fa-solid fa-house"></i>} />
               <TabButton label="Profile" active={tab==='profile'} onClick={()=>setTab('profile')} icon={<i className="fa-solid fa-user"></i>} />

--- a/src/components/ActivePill.tsx
+++ b/src/components/ActivePill.tsx
@@ -2,12 +2,30 @@ import { useEffect, useRef } from 'react';
 
 export function ActivePill({ index, count }: { index: number; count: number }) {
   const ref = useRef<HTMLDivElement | null>(null);
-  useEffect(() => { if (ref.current) ref.current.style.transform = `translateX(${index * 100}%)`; }, [index]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const parent = el.parentElement as HTMLElement | null;
+    if (!parent) return;
+
+    const styles = getComputedStyle(parent);
+    const gap = parseFloat(styles.columnGap || '0');
+    const paddingLeft = parseFloat(styles.paddingLeft || '0');
+    const paddingRight = parseFloat(styles.paddingRight || '0');
+    const available = parent.clientWidth - paddingLeft - paddingRight - gap * (count - 1);
+    const itemWidth = available / count;
+
+    el.style.width = `${itemWidth}px`;
+    el.style.left = `${paddingLeft}px`;
+    el.style.transform = `translateX(${index * (itemWidth + gap)}px)`;
+  }, [index, count]);
+
   return (
     <div
       ref={ref}
-      className="absolute inset-y-1 left-1 rounded-xl bg-blue-900/30 transition-transform duration-300"
-      style={{ width: `${100 / count}%` }}
+      className="absolute top-1 bottom-1 rounded-xl bg-blue-900/30 transition-all duration-300"
       aria-hidden
     />
   );


### PR DESCRIPTION
## Summary
- Add padding and gaps to the tab bar grid for consistent spacing
- Dynamically calculate active pill size and position to avoid overflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e2015910c83219a21eb1f9dd751c0