### PR TITLE
Add CORS headers to trainings API

### DIFF
--- a/pages/api/trainings/[id].ts
+++ b/pages/api/trainings/[id].ts
@@ -5,7 +5,15 @@ import { db, trainings } from '../../../src/db';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { id } = req.query as { id: string };
 
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, PUT, DELETE, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
   switch (req.method) {
+    case 'OPTIONS': {
+      res.status(200).end();
+      break;
+    }
     case 'GET': {
       const result = await db.select().from(trainings).where(eq(trainings.id, id)).limit(1);
       if (!result.length) {
@@ -39,7 +47,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       break;
     }
     default:
-      res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
+      res.setHeader('Allow', ['GET', 'PUT', 'DELETE', 'OPTIONS']);
       res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 }

--- a/pages/api/trainings/index.ts
+++ b/pages/api/trainings/index.ts
@@ -2,7 +2,15 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { db, trainings } from '../../../src/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
   switch (req.method) {
+    case 'OPTIONS': {
+      res.status(200).end();
+      break;
+    }
     case 'GET': {
       const all = await db.select().from(trainings);
       res.status(200).json(all);
@@ -18,7 +26,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       break;
     }
     default:
-      res.setHeader('Allow', ['GET', 'POST']);
+      res.setHeader('Allow', ['GET', 'POST', 'OPTIONS']);
       res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 }


### PR DESCRIPTION
## Summary
- handle CORS preflight with OPTIONS for trainings endpoints
- include CORS headers on all responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f470217b88321b27502606a757d32