### PR TITLE
refactor: align types with data model

### DIFF
--- a/drizzle/0000_initial.sql
+++ b/drizzle/0000_initial.sql
@@ -28,13 +28,5 @@ CREATE TABLE IF NOT EXISTS exercises (
   mode varchar(10) NOT NULL,
   duration_sec integer,
   reps integer,
-  rest_sec integer,
-  cues jsonb
-);
-
-CREATE TABLE IF NOT EXISTS videos (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  title varchar(256) NOT NULL,
-  url varchar(512) NOT NULL,
-  thumbnail varchar(512)
+  rest_sec integer
 );

--- a/pages/api/exercises/[id].ts
+++ b/pages/api/exercises/[id].ts
@@ -16,10 +16,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       break;
     }
     case 'PUT': {
-      const { title, complexId, video, thumbnail, mode, durationSec, reps, restSec, cues } = req.body as any;
+      const { title, complexId, video, thumbnail, mode, durationSec, reps, restSec } = req.body as any;
       const updated = await db
         .update(exercises)
-        .set({ title, complexId, video, thumbnail, mode, durationSec, reps, restSec, cues })
+        .set({ title, complexId, video, thumbnail, mode, durationSec, reps, restSec })
         .where(eq(exercises.id, id))
         .returning();
       if (!updated.length) {

--- a/pages/api/exercises/index.ts
+++ b/pages/api/exercises/index.ts
@@ -9,10 +9,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       break;
     }
     case 'POST': {
-      const { title, complexId, video, thumbnail, mode, durationSec, reps, restSec, cues } = req.body as any;
+      const { title, complexId, video, thumbnail, mode, durationSec, reps, restSec } = req.body as any;
       const inserted = await db
         .insert(exercises)
-        .values({ title, complexId, video, thumbnail, mode, durationSec, reps, restSec, cues })
+        .values({ title, complexId, video, thumbnail, mode, durationSec, reps, restSec })
         .returning();
       res.status(201).json(inserted[0]);
       break;

--- a/src/components/SequenceOverlay.tsx
+++ b/src/components/SequenceOverlay.tsx
@@ -1,30 +1,12 @@
-import { useEffect, useState } from 'react';
 import { useSequenceRunner } from '../hooks/useSequenceRunner';
 import type { Training } from '../types';
 import { EmbedPlayer } from './EmbedPlayer';
 
-export function SequenceOverlay({ training, envReady }: { training: Training; envReady: boolean }) {
+export function SequenceOverlay({ training }: { training: Training }) {
   const s = useSequenceRunner(training);
   const idxLabel = s.complex ? `${s.exIdx + 1}/${s.complex.exercises.length}` : '';
-  const [ttsEnabled, setTtsEnabled] = useState(false);
 
-  useEffect(() => {
-    if (!envReady || !ttsEnabled || !s.ex) return;
-    const cues = s.ex.cues?.filter(c => c.tts) || [];
-    if (cues.length === 0) return;
-    const timers = cues.map(c => setTimeout(() => {
-      try {
-        if ('speechSynthesis' in window) {
-          const u = new SpeechSynthesisUtterance(c.text);
-          window.speechSynthesis.speak(u);
-        }
-      } catch {}
-    }, (c.atSec || 0) * 1000));
-    return () => timers.forEach(clearTimeout);
-  }, [envReady, ttsEnabled, s.ex?.id]);
-
-  const [playTick, setPlayTick] = useState(0);
-  const onPlayPress = () => { setTtsEnabled(true); setPlayTick(t => t + 1); s.play(); };
+  const onPlayPress = () => { s.play(); };
 
   return (
     <div className="p-2 -mx-2">

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -6,9 +6,7 @@ import {
   boolean,
   uuid,
   integer,
-  jsonb,
 } from "drizzle-orm/pg-core";
-import type { Cue } from "../types";
 
 export const users = pgTable("users", {
   id: serial("id").primaryKey(),
@@ -57,12 +55,4 @@ export const exercises = pgTable("exercises", {
   durationSec: integer("duration_sec"),
   reps: integer("reps"),
   restSec: integer("rest_sec"),
-  cues: jsonb("cues").$type<Cue[]>(),
-});
-
-export const videos = pgTable("videos", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  title: varchar("title", { length: 256 }).notNull(),
-  url: varchar("url", { length: 512 }).notNull(),
-  thumbnail: varchar("thumbnail", { length: 512 }),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,35 +1,36 @@
-export type Cue = { atSec: number; text: string; tts?: boolean };
-
-export type Video = {
-  id: string;
-  title: string;
-  url: string;
-  thumbnail?: string;
-};
-
 export type Exercise = {
   id: string;
+  complexId: string;
   title: string;
-  video: string;
-  thumbnail?: string;
-  mode: 'time' | 'reps' | 'demo';
-  durationSec?: number;
-  reps?: number;
+  videoUrl?: string;
+  muxId?: string;
+  videoDurationSec: number;
+  performDurationSec: number;
+  repetitions?: number;
   restSec?: number;
-  cues?: Cue[];
+  notes?: string;
 };
 
 export type Complex = {
   id: string;
-  title: string;
-  exercises: Exercise[];
-  rounds?: number;
-  restBetweenSec?: number;
+  trainingId: string;
+  order: number;
+  rounds: number;
 };
 
-export type Training = { id: string; title: string; complexes: Complex[] };
+export type Training = {
+  id: string;
+  categoryId: string;
+  title: string;
+  description: string;
+  coverUrl: string;
+};
 
-export type Category = { id: string; title: string; trainings: Training[] };
+export type Category = {
+  id: string;
+  title: string;
+  coverUrl: string;
+};
 
 export type User = {
   id: number;


### PR DESCRIPTION
## Summary
- align Category, Training, Complex and Exercise types with the documented data model
- remove obsolete Cue and Video models and related schema, API, and component code

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f48d17e20832190c49bd30ea31643