### PR TITLE
refactor categories into training and exercise sections

### DIFF
--- a/src/components/CategoriesSection.tsx
+++ b/src/components/CategoriesSection.tsx
@@ -1,7 +1,18 @@
+import { TrainingsSection } from './TrainingsSection';
+import { ExercisesSection } from './ExercisesSection';
 import type { Category, Training, Exercise } from '../types';
+
+interface Complex {
+  id: string;
+  title: string;
+  rounds?: number;
+  exercises: Exercise[];
+}
 
 interface CategoriesSectionProps {
   categories: Category[];
+  trainings: Training[];
+  exercises: Complex[];
   selectedCategory: Category | null;
   onSelectCategory: (cat: Category | null) => void;
   selectedCourse: Training | null;
@@ -12,6 +23,8 @@ interface CategoriesSectionProps {
 
 export function CategoriesSection({
   categories,
+  trainings,
+  exercises,
   selectedCategory,
   onSelectCategory,
   selectedCourse,
@@ -44,76 +57,24 @@ export function CategoriesSection({
       )}
 
       {selectedCategory && !selectedCourse && (
-        <div className="px-4 pt-4">
-          <button
-            className="mb-4 text-sm text-gray-400 flex items-center gap-1"
-            onClick={() => onSelectCategory(null)}
-          >
-            <i className="fa-solid fa-chevron-left"></i>
-            <span>Back</span>
-          </button>
-          <h4 className="text-lg font-bold mb-3">{selectedCategory.title}</h4>
-          <div className="grid gap-3">
-            {selectedCategory.trainings.map((t) => (
-              <button
-                key={t.id}
-                className="relative text-left group active:scale-[.99] transition flex items-center gap-3 p-4 rounded-2xl bg-neutral-900 border border-neutral-800"
-                onClick={() => onSelectCourse(t)}
-              >
-                <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium leading-snug line-clamp-2">{t.title}</div>
-                </div>
-                <span className="text-gray-500">
-                  <i className="fa-solid fa-chevron-right"></i>
-                </span>
-              </button>
-            ))}
-          </div>
-        </div>
+        <TrainingsSection
+          category={selectedCategory}
+          trainings={trainings}
+          onSelectCourse={(t) => onSelectCourse(t)}
+          onBack={() => onSelectCategory(null)}
+        />
       )}
 
       {selectedCourse && (
-        <div className="px-4 pt-4">
-          <button
-            className="mb-4 text-sm text-gray-400 flex items-center gap-1"
-            onClick={() => onSelectCourse(null)}
-          >
-            <i className="fa-solid fa-chevron-left"></i>
-            <span>Back</span>
-          </button>
-          <button
-            className="w-full mb-4 px-4 py-3 bg-blue-600 text-white rounded-xl text-sm font-medium hover:bg-blue-500 transition"
-            onClick={onStartCourse}
-          >
-            Start workout
-          </button>
-          <h4 className="text-lg font-bold mb-3">{selectedCourse.title}</h4>
-          <div className="grid gap-4">
-            {selectedCourse.complexes.map((l) => (
-              <div key={l.id} className="rounded-2xl bg-neutral-900 border border-neutral-800 p-4">
-                <div className="font-medium mb-2">
-                  {l.title}
-                  {l.rounds ? ` ×${l.rounds}` : ''}
-                </div>
-                <div className="grid gap-2">
-                  {l.exercises.map((e) => (
-                    <button
-                      key={e.id}
-                      className="w-full text-left p-3 rounded-xl bg-neutral-800 hover:bg-neutral-700 flex items-center justify-between"
-                      onClick={() => onStartExercise(e)}
-                    >
-                      <span className="text-sm">
-                        {e.title} — {e.mode === 'time' ? `${e.durationSec}s` : `${e.reps} reps`}
-                      </span>
-                      <i className="fa-solid fa-play text-blue-400 text-sm"></i>
-                    </button>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
+        <ExercisesSection
+          course={selectedCourse}
+          complexes={exercises}
+          onBack={() => onSelectCourse(null)}
+          onStartCourse={onStartCourse}
+          onStartExercise={onStartExercise}
+        />
       )}
     </>
   );
 }
+

--- a/src/components/CategoriesSection.tsx
+++ b/src/components/CategoriesSection.tsx
@@ -1,18 +1,11 @@
 import { TrainingsSection } from './TrainingsSection';
 import { ExercisesSection } from './ExercisesSection';
-import type { Category, Training, Exercise } from '../types';
-
-interface Complex {
-  id: string;
-  title: string;
-  rounds?: number;
-  exercises: Exercise[];
-}
+import type { Category, Training, Exercise, ComplexWithExercises } from '../types';
 
 interface CategoriesSectionProps {
   categories: Category[];
   trainings: Training[];
-  exercises: Complex[];
+  exercises: ComplexWithExercises[];
   selectedCategory: Category | null;
   onSelectCategory: (cat: Category | null) => void;
   selectedCourse: Training | null;

--- a/src/components/ExercisesSection.tsx
+++ b/src/components/ExercisesSection.tsx
@@ -1,0 +1,62 @@
+import type { Training, Exercise } from '../types';
+
+interface Complex {
+  id: string;
+  title: string;
+  rounds?: number;
+  exercises: Exercise[];
+}
+
+interface ExercisesSectionProps {
+  course: Training;
+  complexes: Complex[];
+  onBack: () => void;
+  onStartCourse: () => void;
+  onStartExercise: (ex: Exercise) => void;
+}
+
+export function ExercisesSection({ course, complexes, onBack, onStartCourse, onStartExercise }: ExercisesSectionProps) {
+  return (
+    <div className="px-4 pt-4">
+      <button
+        className="mb-4 text-sm text-gray-400 flex items-center gap-1"
+        onClick={onBack}
+      >
+        <i className="fa-solid fa-chevron-left"></i>
+        <span>Back</span>
+      </button>
+      <button
+        className="w-full mb-4 px-4 py-3 bg-blue-600 text-white rounded-xl text-sm font-medium hover:bg-blue-500 transition"
+        onClick={onStartCourse}
+      >
+        Start workout
+      </button>
+      <h4 className="text-lg font-bold mb-3">{course.title}</h4>
+      <div className="grid gap-4">
+        {complexes.map((l) => (
+          <div key={l.id} className="rounded-2xl bg-neutral-900 border border-neutral-800 p-4">
+            <div className="font-medium mb-2">
+              {l.title}
+              {l.rounds ? ` ×${l.rounds}` : ''}
+            </div>
+            <div className="grid gap-2">
+              {l.exercises.map((e) => (
+                <button
+                  key={e.id}
+                  className="w-full text-left p-3 rounded-xl bg-neutral-800 hover:bg-neutral-700 flex items-center justify-between"
+                  onClick={() => onStartExercise(e)}
+                >
+                  <span className="text-sm">
+                    {e.title} — {e.mode === 'time' ? `${e.durationSec}s` : `${e.reps} reps`}
+                  </span>
+                  <i className="fa-solid fa-play text-blue-400 text-sm"></i>
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/ExercisesSection.tsx
+++ b/src/components/ExercisesSection.tsx
@@ -1,15 +1,8 @@
-import type { Training, Exercise } from '../types';
-
-interface Complex {
-  id: string;
-  title: string;
-  rounds?: number;
-  exercises: Exercise[];
-}
+import type { Training, Exercise, ComplexWithExercises } from '../types';
 
 interface ExercisesSectionProps {
   course: Training;
-  complexes: Complex[];
+  complexes: ComplexWithExercises[];
   onBack: () => void;
   onStartCourse: () => void;
   onStartExercise: (ex: Exercise) => void;

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import { BannerCarousel } from './BannerCarousel';
 import { CategoriesSection } from './CategoriesSection';
-import type { Category, Training, Exercise } from '../types';
+import type { Category, Training, Exercise, ComplexWithExercises } from '../types';
 import type { Dispatch, SetStateAction } from 'react';
 
 interface HomeTabProps {
@@ -39,7 +39,7 @@ export function HomeTab({ viewerCourse, setViewerCourse }: HomeTabProps) {
   const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
   const [selectedCourse, setSelectedCourse] = useState<Training | null>(null);
   const [trainings, setTrainings] = useState<Training[]>([]);
-  const [exercises, setExercises] = useState<{ id: string; title: string; rounds?: number; exercises: Exercise[] }[]>([]);
+  const [exercises, setExercises] = useState<ComplexWithExercises[]>([]);
 
   useEffect(() => {
     if (selectedCategory) setTrainings(selectedCategory.trainings || []);

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -38,6 +38,19 @@ export function HomeTab({ viewerCourse, setViewerCourse }: HomeTabProps) {
 
   const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
   const [selectedCourse, setSelectedCourse] = useState<Training | null>(null);
+  const [trainings, setTrainings] = useState<Training[]>([]);
+  const [exercises, setExercises] = useState<{ id: string; title: string; rounds?: number; exercises: Exercise[] }[]>([]);
+
+  useEffect(() => {
+    if (selectedCategory) setTrainings(selectedCategory.trainings || []);
+    else setTrainings([]);
+    setSelectedCourse(null);
+  }, [selectedCategory]);
+
+  useEffect(() => {
+    if (selectedCourse) setExercises(selectedCourse.complexes || []);
+    else setExercises([]);
+  }, [selectedCourse]);
 
   const startExercise = (ex: Exercise) => {
     if (!selectedCourse) return;
@@ -56,6 +69,8 @@ export function HomeTab({ viewerCourse, setViewerCourse }: HomeTabProps) {
       )}
       <CategoriesSection
         categories={categories}
+        trainings={trainings}
+        exercises={exercises}
         selectedCategory={selectedCategory}
         onSelectCategory={setSelectedCategory}
         selectedCourse={selectedCourse}

--- a/src/components/TrainingsSection.tsx
+++ b/src/components/TrainingsSection.tsx
@@ -1,0 +1,40 @@
+import type { Category, Training } from '../types';
+
+interface TrainingsSectionProps {
+  category: Category;
+  trainings: Training[];
+  onSelectCourse: (course: Training) => void;
+  onBack: () => void;
+}
+
+export function TrainingsSection({ category, trainings, onSelectCourse, onBack }: TrainingsSectionProps) {
+  return (
+    <div className="px-4 pt-4">
+      <button
+        className="mb-4 text-sm text-gray-400 flex items-center gap-1"
+        onClick={onBack}
+      >
+        <i className="fa-solid fa-chevron-left"></i>
+        <span>Back</span>
+      </button>
+      <h4 className="text-lg font-bold mb-3">{category.title}</h4>
+      <div className="grid gap-3">
+        {trainings.map((t) => (
+          <button
+            key={t.id}
+            className="relative text-left group active:scale-[.99] transition flex items-center gap-3 p-4 rounded-2xl bg-neutral-900 border border-neutral-800"
+            onClick={() => onSelectCourse(t)}
+          >
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium leading-snug line-clamp-2">{t.title}</div>
+            </div>
+            <span className="text-gray-500">
+              <i className="fa-solid fa-chevron-right"></i>
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,11 @@ export type Complex = {
   rounds: number;
 };
 
+export type ComplexWithExercises = Complex & {
+  title: string;
+  exercises: Exercise[];
+};
+
 export type Training = {
   id: string;
   categoryId: string;


### PR DESCRIPTION
## Summary
- extract TrainingsSection and ExercisesSection components
- manage trainings and exercises separately in HomeTab and CategoriesSection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f5e7b82188321b5a96ca538f56968