### PR TITLE
Align admin creation forms with API fields

### DIFF
--- a/pages/admin/categories/[id].tsx
+++ b/pages/admin/categories/[id].tsx
@@ -4,19 +4,19 @@ import AdminLayout from 'src/components/admin/AdminLayout';
 
 type Training = {
   id: string;
-  name: string;
+  title: string;
   description: string;
   coverUrl: string;
 };
 
 type Category = {
   id: string;
-  name: string;
+  title: string;
   coverUrl: string;
   trainings: Training[];
 };
 
-const emptyTraining = { name: '', description: '', coverUrl: '' };
+const emptyTraining = { title: '', description: '', coverUrl: '' };
 
 export default function CategoryDetail() {
   const router = useRouter();
@@ -25,7 +25,6 @@ export default function CategoryDetail() {
   const [trainings, setTrainings] = useState<Training[]>([]);
   const [form, setForm] = useState(emptyTraining);
   const [editId, setEditId] = useState<string | null>(null);
-  const [editingTraining, setEditingTraining] = useState<Training | null>(null);
 
   useEffect(() => {
     if (!id) return;
@@ -46,35 +45,33 @@ export default function CategoryDetail() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!category) return;
-    if (editId && editingTraining) {
-      const updated: Training = {
-        ...editingTraining,
-        name: form.name,
-        description: form.description,
-        coverUrl: form.coverUrl,
-      };
+    const payload = {
+      title: form.title,
+      description: form.description,
+      coverUrl: form.coverUrl,
+      categoryId: category.id,
+    };
+    if (editId) {
       await fetch(`/api/trainings/${editId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(updated),
+        body: JSON.stringify(payload),
       });
     } else {
       await fetch('/api/trainings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ categoryId: category.id, training: form }),
+        body: JSON.stringify(payload),
       });
     }
     setForm(emptyTraining);
     setEditId(null);
-    setEditingTraining(null);
     fetchCategory();
   };
 
   const handleEdit = (training: Training) => {
     setEditId(training.id);
-    setEditingTraining(training);
-    setForm({ name: training.name, description: training.description, coverUrl: training.coverUrl });
+    setForm({ title: training.title, description: training.description, coverUrl: training.coverUrl });
   };
 
   const handleDelete = async (trainingId: string) => {
@@ -86,11 +83,11 @@ export default function CategoryDetail() {
   return (
     <AdminLayout>
       <button onClick={() => router.push('/admin/categories')}>Back</button>
-      <h1>Category: {category?.name}</h1>
+      <h1>Category: {category?.title}</h1>
       <ul>
         {trainings.map((t) => (
           <li key={t.id}>
-            {t.name} ({t.id}){' '}
+            {t.title} ({t.id}){' '}
             <button onClick={() => handleEdit(t)}>Edit</button>
             <button onClick={() => handleDelete(t.id)}>Delete</button>
           </li>
@@ -99,9 +96,9 @@ export default function CategoryDetail() {
       <h2 style={{ marginTop: 30 }}>{editId ? 'Edit' : 'Add'} Training</h2>
       <form onSubmit={handleSubmit}>
         <input
-          value={form.name}
-          onChange={(e) => setForm({ ...form, name: e.target.value })}
-          placeholder="name"
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          placeholder="title"
         />
         <textarea
           value={form.description}

--- a/src/components/admin/CategoriesSection.tsx
+++ b/src/components/admin/CategoriesSection.tsx
@@ -4,7 +4,7 @@ import type { Category } from '../../types';
 
 export function CategoriesSection() {
   const [categories, setCategories] = useState<Category[]>([]);
-  const [form, setForm] = useState({ id: '', title: '' });
+  const [form, setForm] = useState({ title: '', coverUrl: '' });
   const [editId, setEditId] = useState<string | null>(null);
   const router = useRouter();
 
@@ -20,27 +20,28 @@ export function CategoriesSection() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const payload = { title: form.title, coverUrl: form.coverUrl };
     if (editId) {
       await fetch(`/api/categories/${editId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
+        body: JSON.stringify(payload),
       });
     } else {
       await fetch('/api/categories', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
+        body: JSON.stringify(payload),
       });
     }
-    setForm({ id: '', title: '' });
+    setForm({ title: '', coverUrl: '' });
     setEditId(null);
     fetchCategories();
   };
 
   const handleEdit = (cat: Category) => {
     setEditId(cat.id);
-    setForm({ id: cat.id, title: cat.title });
+    setForm({ title: cat.title, coverUrl: cat.coverUrl });
   };
 
   const handleDelete = async (id: string) => {
@@ -86,16 +87,15 @@ export function CategoriesSection() {
       <h2 className="text-xl font-semibold mb-2">{editId ? 'Edit' : 'Add'} Category</h2>
       <form onSubmit={handleSubmit} className="space-y-3 max-w-sm">
         <input
-          value={form.id}
-          onChange={(e) => setForm({ ...form, id: e.target.value })}
-          placeholder="id"
-          disabled={!!editId}
-          className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
-        />
-        <input
           value={form.title}
           onChange={(e) => setForm({ ...form, title: e.target.value })}
           placeholder="title"
+          className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
+        />
+        <input
+          value={form.coverUrl}
+          onChange={(e) => setForm({ ...form, coverUrl: e.target.value })}
+          placeholder="cover URL"
           className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
         />
         <button

--- a/src/components/admin/ExercisesSection.tsx
+++ b/src/components/admin/ExercisesSection.tsx
@@ -2,12 +2,14 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import type { Exercise } from '../../types';
 
-interface DBExercise extends Exercise {
-  complexId: string;
-}
-
 export function ExercisesSection() {
-  const [exercises, setExercises] = useState<DBExercise[]>([]);
+  const [exercises, setExercises] = useState<Exercise[]>([]);
+  const [form, setForm] = useState({
+    title: '',
+    complexId: '',
+    videoDurationSec: 0,
+    performDurationSec: 0,
+  });
   const router = useRouter();
 
   useEffect(() => {
@@ -24,6 +26,17 @@ export function ExercisesSection() {
     setExercises(data);
   };
 
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/exercises', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    setForm({ title: '', complexId: '', videoDurationSec: 0, performDurationSec: 0 });
+    fetchExercises();
+  };
+
   return (
     <>
       <h1>Exercises</h1>
@@ -34,6 +47,32 @@ export function ExercisesSection() {
           </li>
         ))}
       </ul>
+      <h2 style={{ marginTop: 30 }}>Add Exercise</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          placeholder="title"
+        />
+        <input
+          value={form.complexId}
+          onChange={(e) => setForm({ ...form, complexId: e.target.value })}
+          placeholder="complexId"
+        />
+        <input
+          type="number"
+          value={form.videoDurationSec}
+          onChange={(e) => setForm({ ...form, videoDurationSec: Number(e.target.value) })}
+          placeholder="video duration sec"
+        />
+        <input
+          type="number"
+          value={form.performDurationSec}
+          onChange={(e) => setForm({ ...form, performDurationSec: Number(e.target.value) })}
+          placeholder="perform duration sec"
+        />
+        <button type="submit">Create</button>
+      </form>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- ensure category form sends title and coverUrl
- fix training form to use title and correct payload
- add exercise creation form with required fields

## Testing
- `npm test`
- `npx tsc -p . --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689fa0b6045c8321a4e9afef71582464