### PR TITLE
feat(admin): add training creation and mux upload

### DIFF
--- a/pages/admin/categories/[categoryId].tsx
+++ b/pages/admin/categories/[categoryId].tsx
@@ -8,6 +8,7 @@ export default function CategoryDetail() {
   const { categoryId } = router.query as { categoryId?: string };
   const [category, setCategory] = useState<Category | null>(null);
   const [trainings, setTrainings] = useState<Training[]>([]);
+  const [form, setForm] = useState({ title: '', description: '', coverUrl: '' });
 
   useEffect(() => {
     if (!categoryId) return;
@@ -25,6 +26,17 @@ export default function CategoryDetail() {
     setTrainings(data.trainings || []);
   };
 
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/trainings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...form, categoryId }),
+    });
+    setForm({ title: '', description: '', coverUrl: '' });
+    fetchCategory();
+  };
+
   return (
     <AdminLayout>
       <button onClick={() => router.push('/admin/categories')}>Back</button>
@@ -36,6 +48,25 @@ export default function CategoryDetail() {
           </li>
         ))}
       </ul>
+      <h2 style={{ marginTop: 30 }}>Add Training</h2>
+      <form onSubmit={handleCreate}>
+        <input
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          placeholder="title"
+        />
+        <input
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+          placeholder="description"
+        />
+        <input
+          value={form.coverUrl}
+          onChange={(e) => setForm({ ...form, coverUrl: e.target.value })}
+          placeholder="cover url"
+        />
+        <button type="submit">Create</button>
+      </form>
     </AdminLayout>
   );
 }

--- a/pages/admin/categories/[categoryId]/[trainingId].tsx
+++ b/pages/admin/categories/[categoryId]/[trainingId].tsx
@@ -8,6 +8,8 @@ export default function TrainingExercisesPage() {
   const router = useRouter();
   const { categoryId, trainingId } = router.query as { categoryId?: string; trainingId?: string };
   const [training, setTraining] = useState<Training | null>(null);
+  const [progress, setProgress] = useState<number | null>(null);
+  const [assetId, setAssetId] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
@@ -27,10 +29,55 @@ export default function TrainingExercisesPage() {
     setTraining(data);
   };
 
+  const handleFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const file = files[0];
+    const res = await fetch('/api/upload', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ filename: file.name, contentType: file.type }),
+    });
+    const { uploadUrl, assetId: id } = await res.json();
+    await new Promise<void>((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('PUT', uploadUrl);
+      xhr.upload.onprogress = (e) => {
+        if (e.lengthComputable) {
+          setProgress(Math.round((e.loaded / e.total) * 100));
+        }
+      };
+      xhr.onload = () => {
+        setProgress(100);
+        setAssetId(id);
+        resolve();
+      };
+      xhr.onerror = reject;
+      xhr.setRequestHeader('Content-Type', file.type);
+      xhr.send(file);
+    });
+  };
+
   return (
     <AdminLayout>
       <button onClick={() => router.push(`/admin/categories/${categoryId}`)}>Back</button>
       <h1>Training: {training?.title}</h1>
+      <div
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={(e) => {
+          e.preventDefault();
+          handleFiles(e.dataTransfer.files);
+        }}
+        style={{ border: '2px dashed #ccc', padding: 20, marginBottom: 20 }}
+      >
+        <p>Drag & drop video here or choose a file</p>
+        <input type="file" accept="video/*" onChange={(e) => handleFiles(e.target.files)} />
+        {progress !== null && (
+          <progress value={progress} max="100">
+            {progress}%
+          </progress>
+        )}
+        {assetId && <p>Uploaded asset ID: {assetId}</p>}
+      </div>
       <ExercisesSection />
     </AdminLayout>
   );

--- a/pages/api/categories/[id].ts
+++ b/pages/api/categories/[id].ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { eq } from 'drizzle-orm';
-import { db, categories } from '../../../src/db';
+import { db, categories, trainings } from '../../../src/db';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -21,7 +21,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         res.status(404).json({ message: 'Not found' });
         break;
       }
-      res.status(200).json(result[0]);
+      const ts = await db.select().from(trainings).where(eq(trainings.categoryId, id));
+      res.status(200).json({ ...result[0], trainings: ts });
       break;
     }
     case 'PUT': {

--- a/pages/api/upload.ts
+++ b/pages/api/upload.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+    return;
+  }
+
+  const { filename, contentType } = req.body as { filename: string; contentType: string };
+  if (!process.env.MUX_TOKEN_ID || !process.env.MUX_TOKEN_SECRET) {
+    res.status(500).json({ message: 'Mux credentials are not configured' });
+    return;
+  }
+
+  const auth = Buffer.from(`${process.env.MUX_TOKEN_ID}:${process.env.MUX_TOKEN_SECRET}`).toString('base64');
+  const muxRes = await fetch('https://api.mux.com/video/v1/uploads', {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${auth}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      new_asset_settings: { playback_policy: ['public'] },
+      cors_origin: req.headers.origin || '*',
+    }),
+  });
+
+  if (!muxRes.ok) {
+    const err = await muxRes.text();
+    res.status(500).json({ message: 'Mux upload creation failed', details: err });
+    return;
+  }
+
+  const data = await muxRes.json();
+  res.status(200).json({ uploadUrl: data.data.url, uploadId: data.data.id, assetId: data.data.asset_id });
+}


### PR DESCRIPTION
## Summary
- include category trainings in API response
- add training creation form and list in category page
- support drag-and-drop video uploads with progress to Mux

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689faf0d158c83219cb8b146742038b9