### PR TITLE
style: unify admin training pages design

### DIFF
--- a/pages/admin/categories/[categoryId].tsx
+++ b/pages/admin/categories/[categoryId].tsx
@@ -39,33 +39,51 @@ export default function CategoryDetail() {
 
   return (
     <AdminLayout>
-      <button onClick={() => router.push('/admin/categories')}>Back</button>
-      <h1>Category: {category?.title}</h1>
-      <ul>
+      <button
+        className="mb-4 px-3 py-2 text-sm bg-neutral-800 rounded-lg hover:bg-neutral-700"
+        onClick={() => router.push('/admin/categories')}
+      >
+        Back
+      </button>
+      <h1 className="text-2xl font-bold mb-4">Category: {category?.title}</h1>
+      <ul className="space-y-2 mb-8">
         {trainings.map((t) => (
-          <li key={t.id}>
-            <button onClick={() => router.push(`/admin/categories/${categoryId}/${t.id}`)}>{t.title}</button>
+          <li key={t.id} className="bg-neutral-900 px-4 py-2 rounded-lg">
+            <button
+              className="text-blue-400 hover:underline"
+              onClick={() => router.push(`/admin/categories/${categoryId}/${t.id}`)}
+            >
+              {t.title}
+            </button>
           </li>
         ))}
       </ul>
-      <h2 style={{ marginTop: 30 }}>Add Training</h2>
-      <form onSubmit={handleCreate}>
+      <h2 className="text-xl font-semibold mb-2">Add Training</h2>
+      <form onSubmit={handleCreate} className="space-y-3 max-w-sm">
         <input
           value={form.title}
           onChange={(e) => setForm({ ...form, title: e.target.value })}
           placeholder="title"
+          className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
         />
         <input
           value={form.description}
           onChange={(e) => setForm({ ...form, description: e.target.value })}
           placeholder="description"
+          className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
         />
         <input
           value={form.coverUrl}
           onChange={(e) => setForm({ ...form, coverUrl: e.target.value })}
           placeholder="cover url"
+          className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
         />
-        <button type="submit">Create</button>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 rounded-lg text-sm font-medium hover:bg-blue-500"
+        >
+          Create
+        </button>
       </form>
     </AdminLayout>
   );

--- a/pages/admin/categories/[categoryId]/[trainingId].tsx
+++ b/pages/admin/categories/[categoryId]/[trainingId].tsx
@@ -106,53 +106,73 @@ export default function TrainingExercisesPage() {
 
   return (
     <AdminLayout>
-      <button onClick={() => router.push(`/admin/categories/${categoryId}`)}>Back</button>
-      <h1>Training: {training?.title}</h1>
+      <button
+        className="mb-4 px-3 py-2 text-sm bg-neutral-800 rounded-lg hover:bg-neutral-700"
+        onClick={() => router.push(`/admin/categories/${categoryId}`)}
+      >
+        Back
+      </button>
+      <h1 className="text-2xl font-bold mb-4">Training: {training?.title}</h1>
       <div
         onDragOver={(e) => e.preventDefault()}
         onDrop={(e) => {
           e.preventDefault();
           handleFiles(e.dataTransfer.files);
         }}
-        style={{ border: '2px dashed #ccc', padding: 20, marginBottom: 20 }}
+        className="border-2 border-dashed border-neutral-600 rounded-lg p-6 mb-6 text-center"
       >
-        <p>Drag & drop video here or choose files</p>
-        <input type="file" accept="video/*" multiple onChange={(e) => handleFiles(e.target.files)} />
+        <p className="mb-2 text-sm text-gray-400">Drag & drop video here or choose files</p>
+        <input
+          type="file"
+          accept="video/*"
+          multiple
+          onChange={(e) => handleFiles(e.target.files)}
+          className="text-sm"
+        />
         {uploadProgress.map((p, i) => (
-          <progress key={i} value={p} max="100">
+          <progress key={i} value={p} max="100" className="w-full mt-2">
             {p}%
           </progress>
         ))}
       </div>
 
       {pendingExercises.map((ex, idx) => (
-        <div key={idx} style={{ marginBottom: 20 }}>
+        <div key={idx} className="bg-neutral-900 p-4 rounded-lg mb-4 space-y-2">
           {ex.videoUrl && (
-            <video src={ex.videoUrl} controls width={250} style={{ display: 'block', marginBottom: 10 }} />
+            <video src={ex.videoUrl} controls className="w-full rounded mb-2" />
           )}
           <input
             value={ex.title}
             onChange={(e) => updateExercise(idx, 'title', e.target.value)}
             placeholder="title"
+            className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
           />
           <input
             value={ex.complexId}
             onChange={(e) => updateExercise(idx, 'complexId', e.target.value)}
             placeholder="complexId"
+            className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
           />
           <input
             type="number"
             value={ex.videoDurationSec}
             onChange={(e) => updateExercise(idx, 'videoDurationSec', Number(e.target.value))}
             placeholder="video duration sec"
+            className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
           />
           <input
             type="number"
             value={ex.performDurationSec}
             onChange={(e) => updateExercise(idx, 'performDurationSec', Number(e.target.value))}
             placeholder="perform duration sec"
+            className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
           />
-          <button onClick={() => addExercise(idx)}>Add</button>
+          <button
+            className="px-4 py-2 bg-blue-600 rounded-lg text-sm font-medium hover:bg-blue-500"
+            onClick={() => addExercise(idx)}
+          >
+            Add
+          </button>
         </div>
       ))}
 

--- a/src/components/admin/ExercisesSection.tsx
+++ b/src/components/admin/ExercisesSection.tsx
@@ -39,39 +39,48 @@ export function ExercisesSection() {
 
   return (
     <>
-      <h1>Exercises</h1>
-      <ul>
+      <h1 className="text-2xl font-bold mb-4">Exercises</h1>
+      <ul className="space-y-2 mb-8">
         {exercises.map((ex) => (
-          <li key={ex.id}>
+          <li key={ex.id} className="bg-neutral-900 px-4 py-2 rounded-lg">
             {ex.title} – {ex.complexId}
           </li>
         ))}
       </ul>
-      <h2 style={{ marginTop: 30 }}>Add Exercise</h2>
-      <form onSubmit={handleSubmit}>
+      <h2 className="text-xl font-semibold mb-2">Add Exercise</h2>
+      <form onSubmit={handleSubmit} className="space-y-3 max-w-sm">
         <input
           value={form.title}
           onChange={(e) => setForm({ ...form, title: e.target.value })}
           placeholder="title"
+          className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
         />
         <input
           value={form.complexId}
           onChange={(e) => setForm({ ...form, complexId: e.target.value })}
           placeholder="complexId"
+          className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
         />
         <input
           type="number"
           value={form.videoDurationSec}
           onChange={(e) => setForm({ ...form, videoDurationSec: Number(e.target.value) })}
           placeholder="video duration sec"
+          className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
         />
         <input
           type="number"
           value={form.performDurationSec}
           onChange={(e) => setForm({ ...form, performDurationSec: Number(e.target.value) })}
           placeholder="perform duration sec"
+          className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
         />
-        <button type="submit">Create</button>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 rounded-lg text-sm font-medium hover:bg-blue-500"
+        >
+          Create
+        </button>
       </form>
     </>
   );


### PR DESCRIPTION
## Summary
- restyle category detail page to match category creation design
- enhance training detail page with consistent Tailwind styling
- update admin exercises section to share same look

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a025e2760c83219b317dc7bbb84974