### PR TITLE
feat: automate complex handling in training builder

### DIFF
--- a/pages/admin/categories/[categoryId]/[trainingId].tsx
+++ b/pages/admin/categories/[categoryId]/[trainingId].tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import AdminLayout from 'src/components/admin/AdminLayout';
-import { ExercisesSection } from 'src/components/admin/ExercisesSection';
 import type { Training, Exercise } from 'src/types';
 
 export default function TrainingExercisesPage() {
@@ -10,8 +9,12 @@ export default function TrainingExercisesPage() {
   const [training, setTraining] = useState<Training | null>(null);
   const [uploadProgress, setUploadProgress] = useState<number[]>([]);
   type ExerciseForm = Omit<Exercise, 'id'>;
+  const createId = () => Math.random().toString(36).substring(2, 9);
+  const [currentComplexId, setCurrentComplexId] = useState<string>(createId());
+  const [complexesInfo, setComplexesInfo] = useState([
+    { id: currentComplexId, order: 1, rounds: 1 },
+  ]);
   const [pendingExercises, setPendingExercises] = useState<ExerciseForm[]>([]);
-  const [sectionKey, setSectionKey] = useState(0);
 
   useEffect(() => {
     if (typeof window !== 'undefined' && !window.localStorage.getItem('admin-token')) {
@@ -65,7 +68,7 @@ export default function TrainingExercisesPage() {
           ...prev,
           {
             title: '',
-            complexId: '',
+            complexId: currentComplexId,
             muxId: u.assetId,
             videoUrl: `https://stream.mux.com/${u.assetId}.m3u8`,
             videoDurationSec: 0,
@@ -93,15 +96,53 @@ export default function TrainingExercisesPage() {
     });
   };
 
-  const addExercise = async (index: number) => {
-    const ex = pendingExercises[index];
-    await fetch('/api/exercises', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(ex),
-    });
-    setPendingExercises((prev) => prev.filter((_, i) => i !== index));
-    setSectionKey((k) => k + 1);
+  const startNewComplex = () => {
+    const newId = createId();
+    setCurrentComplexId(newId);
+    setComplexesInfo((prev) => [
+      ...prev,
+      { id: newId, order: prev.length + 1, rounds: 1 },
+    ]);
+  };
+
+  const handleCreateTraining = async () => {
+    if (
+      pendingExercises.some(
+        (ex) =>
+          !ex.title ||
+          ex.videoDurationSec <= 0 ||
+          ex.performDurationSec <= 0
+      )
+    ) {
+      alert('Please fill in all fields for each exercise');
+      return;
+    }
+
+    const complexIdMap: Record<string, string> = {};
+    for (const info of complexesInfo) {
+      const res = await fetch('/api/complexes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          trainingId,
+          order: info.order,
+          rounds: info.rounds,
+        }),
+      });
+      const data = await res.json();
+      complexIdMap[info.id] = data.id;
+    }
+
+    for (const ex of pendingExercises) {
+      await fetch('/api/exercises', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...ex, complexId: complexIdMap[ex.complexId] }),
+      });
+    }
+
+    setPendingExercises([]);
+    router.push(`/admin/categories/${categoryId}`);
   };
 
   return (
@@ -113,6 +154,17 @@ export default function TrainingExercisesPage() {
         Back
       </button>
       <h1 className="text-2xl font-bold mb-4">Training: {training?.title}</h1>
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-sm text-neutral-400">
+          Complex #{complexesInfo.findIndex((c) => c.id === currentComplexId) + 1}
+        </span>
+        <button
+          className="px-3 py-2 text-sm bg-neutral-800 rounded-lg hover:bg-neutral-700"
+          onClick={startNewComplex}
+        >
+          Next complex
+        </button>
+      </div>
       <div
         onDragOver={(e) => e.preventDefault()}
         onDrop={(e) => {
@@ -148,12 +200,6 @@ export default function TrainingExercisesPage() {
             className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
           />
           <input
-            value={ex.complexId}
-            onChange={(e) => updateExercise(idx, 'complexId', e.target.value)}
-            placeholder="complexId"
-            className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
-          />
-          <input
             type="number"
             value={ex.videoDurationSec}
             onChange={(e) => updateExercise(idx, 'videoDurationSec', Number(e.target.value))}
@@ -167,16 +213,16 @@ export default function TrainingExercisesPage() {
             placeholder="perform duration sec"
             className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-700 text-sm"
           />
-          <button
-            className="px-4 py-2 bg-blue-600 rounded-lg text-sm font-medium hover:bg-blue-500"
-            onClick={() => addExercise(idx)}
-          >
-            Add
-          </button>
         </div>
       ))}
-
-      <ExercisesSection key={sectionKey} />
+      {pendingExercises.length > 0 && (
+        <button
+          className="mt-4 px-4 py-2 bg-blue-600 rounded-lg text-sm font-medium hover:bg-blue-500"
+          onClick={handleCreateTraining}
+        >
+          Create Training
+        </button>
+      )}
     </AdminLayout>
   );
 }


### PR DESCRIPTION
## Summary
- auto-assign uploaded videos to generated complexes
- validate exercise fields and create training with one final submission
- remove manual complex id input and extra exercise form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a02a3e25bc8321b4d1c3b7f0c2e69f