### PR TITLE
feat: introduce CoverCard and refactor listings

### DIFF
--- a/src/components/CategoriesSection.tsx
+++ b/src/components/CategoriesSection.tsx
@@ -1,5 +1,6 @@
 import { TrainingsSection } from './TrainingsSection';
 import { ExercisesSection } from './ExercisesSection';
+import { CoverCard } from './CoverCard';
 import type { Category, Training, Exercise, ComplexWithExercises } from '../types';
 
 interface CategoriesSectionProps {
@@ -30,20 +31,14 @@ export function CategoriesSection({
       {!selectedCategory && !selectedCourse && (
         <section className="px-4 mt-6">
           <h4 className="text-lg font-bold mb-3">Категории</h4>
-          <div className="grid gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
             {categories.map((cat) => (
-              <button
+              <CoverCard
                 key={cat.id}
-                className="relative text-left group active:scale-[.99] transition flex items-center gap-3 p-4 rounded-2xl bg-neutral-900 border border-neutral-800"
+                title={cat.title}
+                imageUrl={cat.coverUrl}
                 onClick={() => onSelectCategory(cat)}
-              >
-                <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium leading-snug line-clamp-2">{cat.title}</div>
-                </div>
-                <span className="text-gray-500">
-                  <i className="fa-solid fa-chevron-right"></i>
-                </span>
-              </button>
+              />
             ))}
           </div>
         </section>

--- a/src/components/CoverCard.tsx
+++ b/src/components/CoverCard.tsx
@@ -1,0 +1,24 @@
+import Image from 'next/image';
+
+interface CoverCardProps {
+  title: string;
+  imageUrl: string;
+  onClick?: () => void;
+}
+
+export function CoverCard({ title, imageUrl, onClick }: CoverCardProps) {
+  const Component = onClick ? 'button' : 'div';
+  return (
+    <Component
+      onClick={onClick}
+      className="relative h-40 w-full overflow-hidden rounded-2xl text-left hover:scale-[1.02] transition-transform focus-visible:ring"
+    >
+      <Image src={imageUrl} alt={title} fill className="object-cover" />
+      <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent" />
+      <div className="absolute bottom-0 left-0 right-0 p-3 text-white text-sm font-medium">
+        {title}
+      </div>
+    </Component>
+  );
+}
+

--- a/src/components/TrainingsSection.tsx
+++ b/src/components/TrainingsSection.tsx
@@ -1,4 +1,5 @@
 import type { Category, Training } from '../types';
+import { CoverCard } from './CoverCard';
 
 interface TrainingsSectionProps {
   category: Category;
@@ -18,20 +19,14 @@ export function TrainingsSection({ category, trainings, onSelectCourse, onBack }
         <span>Back</span>
       </button>
       <h4 className="text-lg font-bold mb-3">{category.title}</h4>
-      <div className="grid gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
         {trainings.map((t) => (
-          <button
+          <CoverCard
             key={t.id}
-            className="relative text-left group active:scale-[.99] transition flex items-center gap-3 p-4 rounded-2xl bg-neutral-900 border border-neutral-800"
+            title={t.title}
+            imageUrl={t.coverUrl}
             onClick={() => onSelectCourse(t)}
-          >
-            <div className="flex-1 min-w-0">
-              <div className="text-sm font-medium leading-snug line-clamp-2">{t.title}</div>
-            </div>
-            <span className="text-gray-500">
-              <i className="fa-solid fa-chevron-right"></i>
-            </span>
-          </button>
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `CoverCard` component for image-backed cards with gradient and focus/hover effects
- replace duplicated markup in categories and trainings sections using `CoverCard`
- apply grid layouts for category and training cards

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a08ac2e15883219ccbd6dea1db4777